### PR TITLE
Add indicator signals service and API with tests

### DIFF
--- a/portal/backend/controller/indicators.py
+++ b/portal/backend/controller/indicators.py
@@ -2,13 +2,14 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
 
 from ..service.indicator_service import (
     list_types, get_type_details,
     list_instances_meta, get_instance_meta, delete_instance,
-    create_instance, update_instance, overlays_for_instance
+    create_instance, update_instance, overlays_for_instance,
+    generate_signals_for_instance,
 )
 
 router = APIRouter()
@@ -32,6 +33,13 @@ class OverlayRequest(BaseModel):
     end: str
     interval: str
     symbol: Optional[str] = None  # optional override; defaults to stored
+
+class SignalRequest(BaseModel):
+    start: str
+    end: str
+    interval: str
+    symbol: Optional[str] = None
+    config: Dict[str, Any] = Field(default_factory=dict)
 
 # ===== Instances =====
 @router.get("/", response_model=List[IndicatorInstanceOut])
@@ -112,3 +120,27 @@ async def overlays(inst_id: str, req: OverlayRequest):
     except Exception as e:
         logger.exception("Unexpected overlay error")
         raise HTTPException(500, "Unexpected error computing overlays")
+
+
+@router.post("/{inst_id}/signals")
+async def signals(inst_id: str, req: SignalRequest):
+    try:
+        return generate_signals_for_instance(
+            inst_id=inst_id,
+            start=req.start,
+            end=req.end,
+            interval=req.interval,
+            symbol=req.symbol,
+            config=req.config,
+        )
+    except KeyError:
+        raise HTTPException(404, "Indicator not found")
+    except LookupError as e:
+        raise HTTPException(404, str(e))
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    except RuntimeError as e:
+        raise HTTPException(500, str(e))
+    except Exception:
+        logger.exception("Unexpected signal generation error")
+        raise HTTPException(500, "Unexpected error generating signals")

--- a/portal/backend/service/indicator_service.py
+++ b/portal/backend/service/indicator_service.py
@@ -15,6 +15,10 @@ from indicators.vwap import VWAPIndicator
 from indicators.pivot_level import PivotLevelIndicator
 from indicators.trendline import TrendlineIndicator
 from indicators.market_profile import MarketProfileIndicator
+from signals.engine.signal_generator import (
+    build_signal_overlays,
+    run_indicator_rules,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -233,3 +237,56 @@ def overlays_for_instance(
         raise LookupError("No overlays computed for given window")
 
     return payload
+
+
+def generate_signals_for_instance(
+    inst_id: str,
+    start: str,
+    end: str,
+    interval: str,
+    symbol: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Execute registered signal rules for an indicator instance."""
+
+    entry = _REGISTRY.get(inst_id)
+    if not entry:
+        raise KeyError("Indicator not found")
+
+    inst = entry["instance"]
+    base_params = entry["meta"].get("params", {})
+    sym = symbol or base_params.get("symbol")
+    if not sym:
+        raise ValueError("Stored indicator has no symbol and none was provided")
+
+    provider = AlpacaProvider()
+    ctx = DataContext(symbol=sym, start=start, end=end, interval=interval)
+    df = provider.get_ohlcv(ctx)
+    if df is None or df.empty:
+        raise LookupError("No candles available for given window")
+
+    rule_config: Dict[str, Any] = dict(config or {})
+    rule_config.setdefault("pivot_breakout_confirmation_bars", 1)
+
+    logger.info(
+        "Running signal rules for indicator %s (%s) with config=%s",
+        inst_id,
+        getattr(inst, "NAME", inst.__class__.__name__),
+        rule_config,
+    )
+
+    signals = run_indicator_rules(inst, df, **rule_config)
+    overlays = build_signal_overlays(inst, signals, df, **rule_config)
+
+    logger.info(
+        "Signal execution complete for indicator %s: %d signal(s), %d overlay artefact(s)",
+        inst_id,
+        len(signals),
+        len(overlays),
+    )
+
+    sanitized_overlays = _sanitize_json(overlays) or []
+    return {
+        "signals": [sig.to_dict() for sig in signals],
+        "overlays": sanitized_overlays,
+    }

--- a/tests/test_portal/test_indicator_signals.py
+++ b/tests/test_portal/test_indicator_signals.py
@@ -1,0 +1,133 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from portal.backend.main import app
+
+
+class _DummyFrame:
+    def __init__(self, timestamps):
+        self._index = tuple(timestamps)
+        self.empty = len(self._index) == 0
+
+    def copy(self):
+        return _DummyFrame(self._index)
+
+    @property
+    def index(self):
+        return self._index
+
+    def __len__(self):
+        return len(self._index)
+
+
+class _DummyIndicator:
+    NAME = "DummySignalIndicator"
+
+    def __init__(self, symbol: str):
+        self.symbol = symbol
+
+
+def _build_dataframe() -> _DummyFrame:
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    timestamps = [start + timedelta(hours=i) for i in range(3)]
+    return _DummyFrame(timestamps)
+
+
+@pytest.fixture
+def signal_test_env(monkeypatch):
+    from portal.backend.service import indicator_service as svc
+    from signals.engine import signal_generator as engine
+
+    def _setup(df: _DummyFrame):
+        indicator = _DummyIndicator(symbol="ES")
+        inst_id = "test-inst"
+
+        class DummyProvider:
+            def __init__(self, frame: _DummyFrame):
+                self._frame = frame
+
+            def get_ohlcv(self, ctx):
+                return self._frame.copy()
+
+        monkeypatch.setattr(svc, "_REGISTRY", {inst_id: {"meta": {"params": {"symbol": "ES"}}, "instance": indicator}})
+        monkeypatch.setattr(svc, "AlpacaProvider", lambda: DummyProvider(df))
+
+        engine_registry = dict(engine._REGISTRY)
+
+        def dummy_rule(context, payload):
+            return [
+                {
+                    "type": "breakout",
+                    "symbol": context["symbol"],
+                    "time": context["df"].index[-1],
+                    "confirmation": context.get("pivot_breakout_confirmation_bars"),
+                }
+            ]
+
+        def dummy_overlay(signals, plot_df, **kwargs):
+            return [
+                {
+                    "kind": "dummy",
+                    "signals": len(signals),
+                    "bars": len(plot_df),
+                    "confirmation": kwargs.get("pivot_breakout_confirmation_bars"),
+                }
+            ]
+
+        monkeypatch.setattr(engine, "_REGISTRY", engine_registry)
+        engine.register_indicator_rules(_DummyIndicator.NAME, [dummy_rule], overlay_adapter=dummy_overlay)
+
+        client = TestClient(app)
+        return client, inst_id
+
+    return _setup
+
+
+def test_generate_signals_success(signal_test_env):
+    client, inst_id = signal_test_env(_build_dataframe())
+
+    payload = {
+        "start": "2024-01-01T00:00:00Z",
+        "end": "2024-01-01T02:00:00Z",
+        "interval": "1h",
+    }
+
+    response = client.post(f"/api/indicators/{inst_id}/signals", json=payload)
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["signals"], "Expected at least one signal"
+    assert body["signals"][0]["metadata"]["confirmation"] == 1
+    assert body["overlays"][0]["confirmation"] == 1
+
+
+def test_generate_signals_indicator_missing(signal_test_env):
+    client, _ = signal_test_env(_build_dataframe())
+
+    payload = {
+        "start": "2024-01-01T00:00:00Z",
+        "end": "2024-01-01T02:00:00Z",
+        "interval": "1h",
+    }
+
+    response = client.post("/api/indicators/missing-id/signals", json=payload)
+    assert response.status_code == 404
+
+
+def test_generate_signals_no_candles(signal_test_env):
+    empty_df = _DummyFrame(())
+    client, inst_id = signal_test_env(empty_df)
+
+    payload = {
+        "start": "2024-01-01T00:00:00Z",
+        "end": "2024-01-01T02:00:00Z",
+        "interval": "1h",
+    }
+
+    response = client.post(f"/api/indicators/{inst_id}/signals", json=payload)
+    assert response.status_code == 404
+    assert response.json()["detail"] == "No candles available for given window"


### PR DESCRIPTION
## Summary
- add a backend service helper to execute registered signal rules and return overlays alongside serialized signals
- expose a FastAPI route and request schema to trigger signal generation for stored indicator instances
- cover the new endpoint with FastAPI client tests including success, missing indicator, and empty-candle scenarios

## Testing
- pytest tests/test_portal/test_indicator_signals.py

------
https://chatgpt.com/codex/tasks/task_e_68d1cdf9ed108331a51c4981c1540c6f