### PR TITLE
Implement signal generation workflow and tests

### DIFF
--- a/portal/frontend/package.json
+++ b/portal/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.6",

--- a/portal/frontend/src/adapters/indicator.adapter.js
+++ b/portal/frontend/src/adapters/indicator.adapter.js
@@ -63,3 +63,30 @@ export async function fetchIndicatorOverlays(id, { start, end, interval, symbol 
   });
   return handleResponse(res);
 }
+
+export async function generateIndicatorSignals(
+  id,
+  { start, end, interval, symbol, config } = {},
+) {
+  const payload = {
+    start,
+    end,
+    interval,
+  };
+
+  if (symbol) payload.symbol = symbol;
+
+  const cfgEntries = Object.entries(config || {}).filter(([, v]) => v !== undefined && v !== null);
+  if (cfgEntries.length) {
+    payload.config = Object.fromEntries(cfgEntries);
+  }
+
+  const res = await fetch(`${BASE}/api/indicators/${id}/signals`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    mode: 'cors',
+  });
+
+  return handleResponse(res);
+}

--- a/portal/frontend/src/components/IndicatorTab.jsx
+++ b/portal/frontend/src/components/IndicatorTab.jsx
@@ -6,7 +6,9 @@ import {
   updateIndicator,
   deleteIndicator,
   fetchIndicatorOverlays,
+  generateIndicatorSignals,
 } from '../adapters/indicator.adapter'
+import { applyIndicatorColors, runSignalGeneration } from './indicatorSignals.js'
 // import IndicatorModal from './IndicatorModal'
 import IndicatorModalV2 from './IndicatorModal.v2.jsx'
 const IndicatorModal = IndicatorModalV2; // for now, swap in new version under old name
@@ -45,15 +47,6 @@ const normalizeParams = (params) => {
   const p = { ...params };
   if (p.lookbacks !== undefined) p.lookbacks = toIntList(p.lookbacks);
   return p;
-};
-
-const hexToRgba = (hex, a = 0.18) => {
-  if (!hex || !hex.startsWith('#')) return `rgba(156,163,175,${a})`;
-  const v = hex.slice(1);
-  const n = v.length === 3
-    ? v.split('').map(c => parseInt(c + c, 16))
-    : [parseInt(v.slice(0,2),16), parseInt(v.slice(2,4),16), parseInt(v.slice(4,6),16)];
-  return `rgba(${n[0]},${n[1]},${n[2]},${a})`;
 };
 
 // Manages the list of indicators and syncs enabled ones to the chart context
@@ -279,7 +272,19 @@ export const IndicatorSection = ({ chartId }) => {
 
   // Regenerate signals (not yet implemented)
   const generateSignals = async (id) => {
-    console.log('[IndicatorSection] generateSignals not yet implemented', id);
+    const indicator = indicators.find((ind) => ind.id === id);
+    await runSignalGeneration({
+      indicator,
+      chartId,
+      chartState,
+      startISO,
+      endISO,
+      indColors,
+      getChart,
+      updateChart,
+      setError,
+      signalsAdapter: generateIndicatorSignals,
+    });
   };
 
 
@@ -288,42 +293,6 @@ export const IndicatorSection = ({ chartId }) => {
     setModalOpen(true)
     setError(null)
   }
-
-    // apply selected colors to overlays' price_lines and markers
-  const applyIndicatorColors = (overlays = [], colors = {}) =>
-    (overlays || []).map(ov => {
-      if (!ov || !ov.ind_id || !ov.payload) return ov;
-      const color = colors[ov.ind_id];
-      if (!color) return ov;
-
-      // price lines → uniform color
-      const price_lines = Array.isArray(ov.payload.price_lines)
-        ? ov.payload.price_lines.map(pl => ({ ...pl, color }))
-        : ov.payload.price_lines;
-
-      // markers (touch + regular) → override color
-      const markers = Array.isArray(ov.payload.markers)
-        ? ov.payload.markers.map(m => (m ? { ...m, color } : m))
-        : ov.payload.markers;
-
-      const boxes = Array.isArray(ov.payload.boxes)
-        ? ov.payload.boxes.map(b => {
-            if (!b) return b;
-            return { ...b, color: hexToRgba(color, 0.1), border: { color: hexToRgba(color, 0.7), width: 1 } };
-          })
-        : ov.payload.boxes;
-
-        const tintHex = hexToRgba(color, 0.7);
-
-        if (Array.isArray(ov.payload.segments)) {
-          ov.payload.segments = ov.payload.segments.map(s => ({ ...s, color: tintHex }));
-        }
-        if (Array.isArray(ov.payload.polylines)) {
-          ov.payload.polylines = ov.payload.polylines.map(l => ({ ...l, color: tintHex }));
-        }
-
-      return { ...ov, payload: { ...ov.payload, price_lines, markers, boxes } };
-    });
 
   const handleSelectColor = (indicatorId, color) => {
     setIndColors(prev => ({ ...prev, [indicatorId]: color }));

--- a/portal/frontend/src/components/indicatorSignals.js
+++ b/portal/frontend/src/components/indicatorSignals.js
@@ -1,0 +1,134 @@
+export const hexToRgba = (hex, a = 0.18) => {
+  if (!hex || !hex.startsWith('#')) return `rgba(156,163,175,${a})`;
+  const v = hex.slice(1);
+  const n = v.length === 3
+    ? v.split('').map(c => parseInt(c + c, 16))
+    : [parseInt(v.slice(0, 2), 16), parseInt(v.slice(2, 4), 16), parseInt(v.slice(4, 6), 16)];
+  return `rgba(${n[0]},${n[1]},${n[2]},${a})`;
+};
+
+export const applyIndicatorColors = (overlays = [], colors = {}) =>
+  (overlays || []).map(ov => {
+    if (!ov || !ov.ind_id || !ov.payload) return ov;
+    const color = colors[ov.ind_id] || ov.color;
+    if (!color) return ov;
+
+    const price_lines = Array.isArray(ov.payload.price_lines)
+      ? ov.payload.price_lines.map(pl => (pl ? { ...pl, color } : pl))
+      : ov.payload.price_lines;
+
+    const markers = Array.isArray(ov.payload.markers)
+      ? ov.payload.markers.map(m => (m ? { ...m, color } : m))
+      : ov.payload.markers;
+
+    const boxes = Array.isArray(ov.payload.boxes)
+      ? ov.payload.boxes.map(b => {
+          if (!b) return b;
+          return { ...b, color: hexToRgba(color, 0.1), border: { color: hexToRgba(color, 0.7), width: 1 } };
+        })
+      : ov.payload.boxes;
+
+    const tintHex = hexToRgba(color, 0.7);
+
+    const segments = Array.isArray(ov.payload.segments)
+      ? ov.payload.segments.map(s => (s ? { ...s, color: tintHex } : s))
+      : ov.payload.segments;
+
+    const polylines = Array.isArray(ov.payload.polylines)
+      ? ov.payload.polylines.map(l => (l ? { ...l, color: tintHex } : l))
+      : ov.payload.polylines;
+
+    return {
+      ...ov,
+      color,
+      payload: {
+        ...ov.payload,
+        price_lines,
+        markers,
+        boxes,
+        segments,
+        polylines,
+      },
+    };
+  });
+
+export async function runSignalGeneration({
+  indicator,
+  chartId,
+  chartState,
+  startISO,
+  endISO,
+  indColors,
+  getChart,
+  updateChart,
+  setError,
+  signalsAdapter,
+  colorizer = applyIndicatorColors,
+}) {
+  if (!indicator) {
+    setError?.('Cannot generate signals: indicator not found.');
+    return false;
+  }
+
+  if (!chartState || !chartState.symbol || !chartState.interval) {
+    setError?.('Cannot generate signals: missing chart symbol or interval.');
+    return false;
+  }
+
+  if (!startISO || !endISO) {
+    setError?.('Cannot generate signals: chart window is not ready.');
+    return false;
+  }
+
+  updateChart(chartId, { signalsLoading: true });
+
+  try {
+    const confirmationBars = chartState?.signalsConfig?.pivotBreakoutConfirmationBars
+      ?? indicator?.params?.pivot_breakout_confirmation_bars
+      ?? indicator?.params?.pivot_breakout_config?.confirmation_bars;
+
+    const config = {};
+    if (confirmationBars != null) {
+      config.pivot_breakout_confirmation_bars = confirmationBars;
+    }
+
+    const response = await signalsAdapter(indicator.id, {
+      start: startISO,
+      end: endISO,
+      interval: chartState.interval,
+      symbol: chartState.symbol,
+      config,
+    });
+
+    const rawSignals = Array.isArray(response?.signals) ? response.signals : [];
+    const signalOverlays = Array.isArray(response?.overlays) ? response.overlays : [];
+
+    const annotatedSignals = signalOverlays.map(ov => ({
+      ...ov,
+      ind_id: indicator.id,
+      source: 'signals',
+    }));
+
+    const current = (getChart(chartId)?.overlays || []).filter(Boolean);
+    const withoutOldSignals = current.filter(ov => !(ov?.ind_id === indicator.id && ov?.source === 'signals'));
+    const merged = [...withoutOldSignals, ...annotatedSignals];
+
+    const colored = colorizer(merged, indColors);
+
+    const prevSignals = getChart(chartId)?.signalResults || {};
+    updateChart(chartId, {
+      overlays: colored,
+      signalResults: { ...prevSignals, [indicator.id]: rawSignals },
+    });
+
+    setError?.(null);
+    return true;
+  } catch (err) {
+    const msg = err?.message || 'Failed to generate signals.';
+    console.error(`[IndicatorSection] generateSignals failed for ${indicator?.id}:`, err);
+    setError?.(msg);
+    return false;
+  } finally {
+    updateChart(chartId, { signalsLoading: false });
+  }
+}

--- a/portal/frontend/tests/indicatorSignals.test.js
+++ b/portal/frontend/tests/indicatorSignals.test.js
@@ -1,0 +1,127 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runSignalGeneration } from '../src/components/indicatorSignals.js';
+
+const START = '2024-01-01T00:00:00Z';
+const END = '2024-01-01T02:00:00Z';
+
+function createSignalsAdapter(response) {
+  return async (id, payload) => {
+    assert.equal(id, 'ind-1');
+    assert.deepEqual(payload, {
+      start: START,
+      end: END,
+      interval: '1h',
+      symbol: 'ES',
+      config: { pivot_breakout_confirmation_bars: 2 },
+    });
+    return response;
+  };
+}
+
+test('runSignalGeneration merges overlays and toggles loading flag', async () => {
+  const indicator = {
+    id: 'ind-1',
+    params: { pivot_breakout_confirmation_bars: 2 },
+  };
+
+  const chartState = {
+    symbol: 'ES',
+    interval: '1h',
+    signalsConfig: { pivotBreakoutConfirmationBars: 2 },
+  };
+
+  const indColors = { 'ind-1': '#facc15' };
+
+  let currentState = {
+    overlays: [
+      { ind_id: 'ind-1', source: 'indicator', payload: { markers: [], price_lines: [] } },
+      { ind_id: 'ind-1', source: 'signals', payload: { markers: [{ time: 0, price: 90, color: '#fff' }], price_lines: [] } },
+    ],
+    signalResults: { 'ind-1': [{ legacy: true }] },
+  };
+
+  const updateCalls = [];
+  const updateChart = (chartId, patch) => {
+    assert.equal(chartId, 'chart-1');
+    updateCalls.push(patch);
+    currentState = { ...currentState, ...patch };
+  };
+
+  const getChart = () => currentState;
+
+  const adapterResponse = {
+    signals: [
+      { type: 'breakout', symbol: 'ES', time: START },
+    ],
+    overlays: [
+      {
+        type: 'pivot_level',
+        payload: {
+          markers: [
+            { time: 1704067200, price: 120, color: '#6b7280' },
+          ],
+          price_lines: [
+            { price: 120, color: '#6b7280' },
+          ],
+        },
+      },
+    ],
+  };
+
+  let errorMsg = 'seed';
+  const setError = (msg) => { errorMsg = msg; };
+
+  const success = await runSignalGeneration({
+    indicator,
+    chartId: 'chart-1',
+    chartState,
+    startISO: START,
+    endISO: END,
+    indColors,
+    getChart,
+    updateChart,
+    setError,
+    signalsAdapter: createSignalsAdapter(adapterResponse),
+  });
+
+  assert.equal(success, true);
+  assert.equal(errorMsg, null);
+  assert.deepEqual(updateCalls[0], { signalsLoading: true });
+  assert.deepEqual(updateCalls.at(-1), { signalsLoading: false });
+
+  const overlayPatch = updateCalls.find(call => Object.prototype.hasOwnProperty.call(call, 'overlays'));
+  assert.ok(overlayPatch, 'expected overlays patch to be emitted');
+  assert.equal(overlayPatch.overlays.length, 2);
+
+  const signalOverlay = overlayPatch.overlays.find(ov => ov.source === 'signals');
+  assert.ok(signalOverlay, 'expected signal overlay to be present');
+  assert.equal(signalOverlay.payload.markers[0].color, '#facc15');
+
+  const finalState = getChart();
+  assert.equal(finalState.signalResults['ind-1'].length, 1);
+  assert.equal(finalState.signalResults['ind-1'][0].type, 'breakout');
+});
+
+test('runSignalGeneration exits early when chart context missing', async () => {
+  const indicator = { id: 'ind-1', params: {} };
+  let errorMsg = null;
+  const updateCalls = [];
+  const success = await runSignalGeneration({
+    indicator,
+    chartId: 'chart-1',
+    chartState: { symbol: null, interval: null },
+    startISO: START,
+    endISO: END,
+    indColors: {},
+    getChart: () => ({ overlays: [] }),
+    updateChart: (id, patch) => updateCalls.push({ id, patch }),
+    setError: (msg) => { errorMsg = msg; },
+    signalsAdapter: async () => ({ signals: [], overlays: [] }),
+  });
+
+  assert.equal(success, false);
+  assert.equal(errorMsg, 'Cannot generate signals: missing chart symbol or interval.');
+  assert.equal(updateCalls.length, 0);
+});


### PR DESCRIPTION
## Summary
- add a client adapter helper to call the indicator signals endpoint with the active chart window and rule config
- refactor the indicator tab to share color utilities, reuse a shared signal generation helper, and persist raw signals in chart state
- add a node-based regression test covering signal overlay merging and loading flag transitions

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1d076a9808331ad9c854ed6fce8cc