### PR TITLE
Fix pivot signal registration and improve signal UX

### DIFF
--- a/portal/backend/service/indicator_service.py
+++ b/portal/backend/service/indicator_service.py
@@ -19,6 +19,7 @@ from signals.engine.signal_generator import (
     build_signal_overlays,
     run_indicator_rules,
 )
+from signals.rules.pivot import register_pivot_indicator
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,9 @@ _INDICATOR_MAP = {
     "trendline":      TrendlineIndicator,
     "market_profile": MarketProfileIndicator,
 }
+
+# Ensure default signal rules are registered for built-in indicators
+register_pivot_indicator()
 
 # In-memory registry: id -> {"meta": <pydantic-like dict>, "instance": <object>}
 _REGISTRY: Dict[str, Dict[str, Any]] = {}

--- a/portal/frontend/src/adapters/indicator.adapter.js
+++ b/portal/frontend/src/adapters/indicator.adapter.js
@@ -1,11 +1,36 @@
 const BASE = import.meta.env.REACT_APP_API_BASE_URL || 'http://localhost:8000'
 
 async function handleResponse(res) {
-  if (!res.ok) {
-    const txt = await res.text()
-    throw new Error(txt || res.statusText)
+  if (res.ok) {
+    return res.status === 204 ? null : res.json()
   }
-  return res.status === 204 ? null : res.json()
+
+  const contentType = res.headers.get('content-type') || ''
+  let payload = null
+
+  try {
+    if (contentType.includes('application/json')) {
+      payload = await res.json()
+    } else {
+      const text = await res.text()
+      payload = text || null
+    }
+  } catch (err) {
+    console.warn('[IndicatorAdapter] Failed to parse error response:', err)
+  }
+
+  const detail =
+    (payload && typeof payload === 'object' && (payload.detail || payload.message)) ||
+    (typeof payload === 'string' ? payload : null)
+
+  const message = detail || res.statusText || `Request failed with status ${res.status}`
+  const error = new Error(message)
+  error.status = res.status
+  if (payload && typeof payload === 'object') {
+    error.payload = payload
+  }
+
+  throw error
 }
 
 export async function fetchIndicators() {

--- a/portal/frontend/src/components/IndicatorCard.jsx
+++ b/portal/frontend/src/components/IndicatorCard.jsx
@@ -32,6 +32,8 @@ export default function IndicatorCard({
   onDelete,
   onGenerateSignals,
   onSelectColor,
+  isGeneratingSignals = false,
+  disableSignalAction = false,
 }) {
   const [showAdvanced, setShowAdvanced] = useState(false);
 
@@ -183,14 +185,26 @@ export default function IndicatorCard({
 
         {/* Generate Signals */}
         <button
+          type="button"
           onClick={() => onGenerateSignals?.(indicator.id)}
-          className="text-green-400 hover:text-green-200"
-          title="Generate signals"
+          className={`relative flex h-8 w-8 items-center justify-center rounded-full border border-green-500/40 text-green-300 transition ${
+            disableSignalAction ? 'opacity-50 cursor-not-allowed' : 'hover:text-green-100 hover:border-green-400'
+          }`}
+          title={isGeneratingSignals ? 'Generating…' : 'Generate signals'}
+          disabled={disableSignalAction || isGeneratingSignals}
+          aria-busy={isGeneratingSignals}
         >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.6" stroke="currentColor" className="size-6">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15.91 11.672a.375.375 0 0 1 0 .656l-5.603 3.113a.375.375 0 0 1-.557-.328V8.887c0-.286.307-.466.557-.327l5.603 3.112Z" />
-          </svg>
+          {isGeneratingSignals ? (
+            <svg className="size-4 animate-spin" viewBox="0 0 24 24" role="status" aria-label="Generating signals">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+            </svg>
+          ) : (
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.6" stroke="currentColor" className="size-5">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.91 11.672a.375.375 0 0 1 0 .656l-5.603 3.113a.375.375 0 0 1-.557-.328V8.887c0-.286.307-.466.557-.327l5.603 3.112Z" />
+            </svg>
+          )}
         </button>
 
         {/* Copy JSON */}

--- a/portal/frontend/src/components/IndicatorTab.jsx
+++ b/portal/frontend/src/components/IndicatorTab.jsx
@@ -1,5 +1,6 @@
-import  { useState, useEffect, Fragment, useMemo } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { Switch, Popover, Transition, PopoverButton, PopoverPanel } from '@headlessui/react'
+import { X } from 'lucide-react'
 import {
   fetchIndicators,
   createIndicator,
@@ -298,13 +299,40 @@ export const IndicatorSection = ({ chartId }) => {
     setIndColors(prev => ({ ...prev, [indicatorId]: color }));
   };
 
-  if (isLoading) return <div>Loading indicators…</div>
-  if (error) return <div className="text-red-500">Error: {error}</div>
   if (!chartState || !chartId) return <div className="text-red-500">Error: No chart state found</div>
 
+  const isSignalsLoading = !!chartState?.signalsLoading
+  const signalsLoadingFor = chartState?.signalsLoadingFor
 
   return (
     <div className="space-y-6">
+      {error && (
+        <div className="relative rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-100 shadow-inner">
+          <div className="pr-6">
+            <p className="font-medium text-red-200">Request failed</p>
+            <p className="mt-1 text-red-100">{error}</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setError(null)}
+            className="absolute right-3 top-3 text-red-200/80 hover:text-red-100"
+            aria-label="Dismiss error"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="flex items-center gap-2 rounded-lg border border-neutral-800 bg-neutral-900/60 px-3 py-2 text-sm text-neutral-300">
+          <svg className="size-4 animate-spin text-blue-300" viewBox="0 0 24 24" role="status" aria-hidden="true">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+          </svg>
+          Loading indicators…
+        </div>
+      )}
+
       <button
         onClick={() => openEditModal()}
         className="flex flex-col items-center w-full px-4 py-3 rounded-lg bg-neutral-900 text-neutral-400 hover:text-neutral-100 shadow-lg cursor-pointer transition-colors"
@@ -318,18 +346,31 @@ export const IndicatorSection = ({ chartId }) => {
 
       {/* List of indicators */}
       <div className="space-y-1">
-          {indicators.map(indicator => (
-            <IndicatorCard
-              key={indicator.id}
-              indicator={indicator}
-              color={indColors[indicator.id] || '#60a5fa'}
-              onToggle={toggleEnable}
-              onEdit={openEditModal}
-              onDelete={handleDelete}
-              onGenerateSignals={generateSignals}
-              onSelectColor={handleSelectColor}
-            />
-          ))}
+          {indicators.map(indicator => {
+            const isGenerating = isSignalsLoading && signalsLoadingFor === indicator.id
+            const disableSignals = isSignalsLoading && signalsLoadingFor !== indicator.id
+            return (
+              <IndicatorCard
+                key={indicator.id}
+                indicator={indicator}
+                color={indColors[indicator.id] || '#60a5fa'}
+                onToggle={toggleEnable}
+                onEdit={openEditModal}
+                onDelete={handleDelete}
+                onGenerateSignals={generateSignals}
+                onSelectColor={handleSelectColor}
+                colorSwatches={COLOR_SWATCHES}
+                isGeneratingSignals={isGenerating}
+                disableSignalAction={disableSignals}
+              />
+            )
+          })}
+
+          {!isLoading && indicators.length === 0 && (
+            <div className="rounded-lg border border-dashed border-neutral-800 bg-neutral-900/40 px-4 py-6 text-center text-sm text-neutral-400">
+              No indicators yet. Create one to get started.
+            </div>
+          )}
       </div>
 
       <IndicatorModal

--- a/portal/frontend/src/components/indicatorSignals.js
+++ b/portal/frontend/src/components/indicatorSignals.js
@@ -80,7 +80,7 @@ export async function runSignalGeneration({
     return false;
   }
 
-  updateChart(chartId, { signalsLoading: true });
+  updateChart(chartId, { signalsLoading: true, signalsLoadingFor: indicator.id });
 
   try {
     const confirmationBars = chartState?.signalsConfig?.pivotBreakoutConfirmationBars
@@ -129,6 +129,6 @@ export async function runSignalGeneration({
     setError?.(msg);
     return false;
   } finally {
-    updateChart(chartId, { signalsLoading: false });
+    updateChart(chartId, { signalsLoading: false, signalsLoadingFor: null });
   }
 }

--- a/tests/test_portal/test_indicator_signals.py
+++ b/tests/test_portal/test_indicator_signals.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+import importlib
 
 import pytest
 
@@ -6,6 +7,22 @@ pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from portal.backend.main import app
+from signals.engine import signal_generator as engine
+from signals.rules.pivot import PivotLevelIndicator
+
+
+def test_indicator_service_registers_pivot_rules():
+    module = importlib.import_module("portal.backend.service.indicator_service")
+    original_registry = dict(engine._REGISTRY)
+
+    try:
+        engine._REGISTRY.clear()
+        importlib.reload(module)
+
+        assert PivotLevelIndicator.NAME in engine._REGISTRY
+    finally:
+        engine._REGISTRY.clear()
+        engine._REGISTRY.update(original_registry)
 
 
 class _DummyFrame:


### PR DESCRIPTION
## Summary
- ensure pivot breakout rules are registered when the indicator service loads so pivot-level signal generation works
- improve API error handling and feedback in the indicator tab, including a dismissible banner and loading affordances
- add a spinner state for the signal generation button and wire chart state loading flags to disable concurrent runs
- add a regression test proving the service registers pivot rules on import

## Testing
- `pytest tests/test_portal/test_indicator_signals.py` *(skipped: FastAPI not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d6bedbb48331a4e60863ab92ee02