### PR TITLE
Allow pivot overlays to ignore extra config

### DIFF
--- a/src/signals/rules/pivot.py
+++ b/src/signals/rules/pivot.py
@@ -194,6 +194,7 @@ _BREAKOUT_COLORS = {
 def pivot_signals_to_overlays(
     signals: Sequence[BaseSignal],
     plot_df: "pd.DataFrame",
+    **_ignored: Any,
 ) -> List[Dict[str, Any]]:
     """Convert pivot breakout signals into Lightweight Charts overlay payloads."""
 


### PR DESCRIPTION
## Summary
- allow the pivot overlay adapter to accept and ignore extra configuration arguments so rule configs with additional settings no longer fail

## Testing
- pytest tests/test_signals/test_pivot_signal_overlays.py

------
https://chatgpt.com/codex/tasks/task_e_68d1dcb2b774833180910adb34cf73d4