### PR TITLE
Enhance pivot signal debug tracing

### DIFF
--- a/src/indicators/pivot_level.py
+++ b/src/indicators/pivot_level.py
@@ -3,9 +3,12 @@ from .config import DataContext
 from typing import List, Optional, Tuple, Set, Dict, Any
 import pandas as pd
 from mplfinance.plotting import make_addplot
-from core.logger import logger
+from core.logger import logger as core_logger
 from matplotlib import patches
 from .base import BaseIndicator
+
+log = core_logger.getChild("PivotLevelIndicator")
+
 
 @dataclass
 class Level:
@@ -36,9 +39,12 @@ class Level:
         mask = (df['low'] <= self.price) & (df['high'] >= self.price)
         touches = df[mask].index.tolist()
         self.touches = touches
-        logger.debug(
-            "Level %s at %.4f touched %d times.",
-            self.kind, self.price, len(touches)
+        log.debug(
+            "%s | touches | level_kind=%s | price=%.5f | count=%d",
+            getattr(self, "trace_id", "pivotlvl"),
+            self.kind,
+            self.price,
+            len(touches),
         )
         return touches
 
@@ -69,6 +75,16 @@ class PivotLevelIndicator(BaseIndicator):
         self.threshold = threshold
         self.days_back = days_back
         self.levels: List[Level] = []
+        self.trace_id = self._build_trace_id()
+
+        log.debug(
+            "%s | init | timeframe=%s | lookbacks=%s | threshold=%.5f | bars=%d",
+            self.trace_id,
+            self.timeframe,
+            self.lookbacks,
+            self.threshold,
+            len(self.df),
+        )
         self._compute()
 
     def _compute(self):
@@ -82,23 +98,56 @@ class PivotLevelIndicator(BaseIndicator):
         last_price = self.df['close'].iloc[-1]
         levels: List[Level] = []
 
+        log.debug(
+            "%s | compute | last_price=%.5f | pivot_batches=%d",
+            self.trace_id,
+            last_price,
+            len(pivot_map),
+        )
+
         for lb, (highs, lows) in pivot_map.items():
+            log.debug(
+                "%s | pivots | lookback=%d | highs=%d | lows=%d",
+                self.trace_id,
+                lb,
+                len(highs),
+                len(lows),
+            )
             for ts, price in highs + lows:
                 # skip if within threshold of existing
                 if any(abs(price - lvl.price) / price < self.threshold for lvl in levels):
+                    log.debug(
+                        "%s | dedupe_skip | lookback=%d | price=%.5f",
+                        self.trace_id,
+                        lb,
+                        price,
+                    )
                     continue
                 kind = 'support' if last_price > price else 'resistance'
-                levels.append(
-                    Level(
-                        price=price,
-                        kind=kind,
-                        lookback=lb,
-                        first_touched=ts,
-                        timeframe=self.timeframe
-                    )
+                level = Level(
+                    price=price,
+                    kind=kind,
+                    lookback=lb,
+                    first_touched=ts,
+                    timeframe=self.timeframe
+                )
+                level.trace_id = self.trace_id  # type: ignore[attr-defined]
+                levels.append(level)
+                log.debug(
+                    "%s | level_add | lookback=%d | kind=%s | price=%.5f | first_touched=%s",
+                    self.trace_id,
+                    lb,
+                    kind,
+                    price,
+                    ts,
                 )
         # sort levels and assign
         self.levels = sorted(levels, key=lambda lvl: lvl.price)
+        log.debug(
+            "%s | compute_complete | level_count=%d",
+            self.trace_id,
+            len(self.levels),
+        )
 
     def _find_pivots(self, lookback: int) -> Tuple[List[Tuple[pd.Timestamp, float]], List[Tuple[pd.Timestamp, float]]]:
         """
@@ -107,6 +156,8 @@ class PivotLevelIndicator(BaseIndicator):
         :param lookback: number of bars on each side for pivot detection
         :return: (highs, lows) lists of (timestamp, price)
         """
+        log.debug("%s | find_pivots_start | lookback=%d", self.trace_id, lookback)
+
         highs, lows = [], []
         def near_existing(price):
             return any(abs(price - p) / p < self.threshold for _, p in highs + lows)
@@ -121,7 +172,18 @@ class PivotLevelIndicator(BaseIndicator):
                 highs.append((ts, high))
             elif low < window_low.min() and not near_existing(low):
                 lows.append((ts, low))
+        log.debug(
+            "%s | find_pivots_done | lookback=%d | highs=%d | lows=%d",
+            self.trace_id,
+            lookback,
+            len(highs),
+            len(lows),
+        )
         return highs, lows
+
+    def _build_trace_id(self) -> str:
+        last_index = self.df.index[-1] if not self.df.empty else "na"
+        return f"pivotlvl|tf={self.timeframe}|bars={len(self.df)}|end={last_index}"
 
     def to_overlays(
         self,

--- a/src/signals/rules/pivot.py
+++ b/src/signals/rules/pivot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
@@ -23,7 +24,32 @@ class PivotBreakoutConfig:
             raise ValueError("confirmation_bars must be >= 1")
 
 
+log = logging.getLogger("PivotBreakoutRule")
+
 _DEFAULT_CONFIG = PivotBreakoutConfig()
+
+
+def _summarise_level(level: Level) -> str:
+    return "|".join(
+        [
+            f"px={getattr(level, 'price', 'na'):.5f}" if hasattr(level, "price") else "px=na",
+            f"kind={getattr(level, 'kind', 'na')}",
+            f"lb={getattr(level, 'lookback', 'na')}",
+            f"tf={getattr(level, 'timeframe', 'na')}",
+        ]
+    )
+
+
+def _build_run_id(indicator: PivotLevelIndicator, df: pd.DataFrame, symbol: str) -> str:
+    last_index = df.index[-1] if len(df.index) else "na"
+    return "|".join(
+        [
+            "pivotbrk",
+            f"symbol={symbol}",
+            f"trace={getattr(indicator, 'trace_id', 'na')}",
+            f"end={last_index}",
+        ]
+    )
 
 
 def _to_datetime(value: Any) -> Any:
@@ -51,7 +77,13 @@ def _resolve_config(context: Mapping[str, Any]) -> PivotBreakoutConfig:
     if confirmation_bars < 1:
         confirmation_bars = _DEFAULT_CONFIG.confirmation_bars
 
-    return PivotBreakoutConfig(confirmation_bars=confirmation_bars)
+    resolved = PivotBreakoutConfig(confirmation_bars=confirmation_bars)
+    log.debug(
+        "pivotbrk | config_resolved | confirmation_bars=%d | context_keys=%s",
+        resolved.confirmation_bars,
+        sorted(context.keys()),
+    )
+    return resolved
 
 
 def _ensure_indicator_levels(indicator: Any) -> Iterable[Level]:
@@ -81,6 +113,11 @@ def _evaluate_level(
         raise KeyError("DataFrame must contain a 'close' column for pivot breakout rule")
 
     if len(df) <= confirmation_bars:
+        log.debug(
+            "pivotbrk | level_skip | reason=insufficient_bars | required=%d | available=%d",
+            confirmation_bars + 1,
+            len(df),
+        )
         return None
 
     closes = df["close"]
@@ -96,7 +133,21 @@ def _evaluate_level(
         was_in_range = prev_close <= level.price
         breakout_side = "above"
 
-    if not was_in_range or not _level_out_of_range(out_of_range):
+    level_id = _summarise_level(level)
+    if not was_in_range:
+        log.debug(
+            "pivotbrk | level_skip | level=%s | reason=never_in_range | prev_close=%.5f",
+            level_id,
+            prev_close,
+        )
+        return None
+
+    if not _level_out_of_range(out_of_range):
+        log.debug(
+            "pivotbrk | level_skip | level=%s | reason=confirmation_failed | confirmation_bars=%d",
+            level_id,
+            confirmation_bars,
+        )
         return None
 
     breakout_start_idx = df.index[-confirmation_bars]
@@ -120,6 +171,13 @@ def _evaluate_level(
         if column in df.columns:
             meta[f"trigger_{column}"] = float(last_bar[column])
 
+    log.debug(
+        "pivotbrk | level_breakout | level=%s | direction=%s | trigger_close=%.5f",
+        level_id,
+        breakout_side,
+        last_bar["close"],
+    )
+
     return meta
 
 
@@ -131,27 +189,54 @@ def pivot_breakout_rule(
 
     indicator = context.get("indicator")
     if not isinstance(indicator, PivotLevelIndicator):
+        log.debug(
+            "pivotbrk | guard_fail | reason=indicator_type | indicator=%r",
+            type(indicator),
+        )
         return []
 
     df = context.get("df")
     if df is None or df.empty:
+        log.debug(
+            "pivotbrk | guard_fail | reason=missing_df | indicator=%s",
+            getattr(indicator, "NAME", type(indicator)),
+        )
         return []
 
     levels = _ensure_indicator_levels(indicator)
     if not levels:
+        log.debug(
+            "pivotbrk | guard_fail | reason=no_levels | indicator_trace=%s",
+            getattr(indicator, "trace_id", "unknown"),
+        )
         return []
 
     symbol = _select_symbol(context, indicator)
     if symbol is None:
+        log.debug(
+            "pivotbrk | guard_fail | reason=no_symbol | indicator_trace=%s",
+            getattr(indicator, "trace_id", "unknown"),
+        )
         return []
 
     config = _resolve_config(context)
     confirmation_bars = config.confirmation_bars
 
+    run_id = _build_run_id(indicator, df, symbol)
+    log.debug(
+        "%s | run_start | levels=%d | confirmation_bars=%d",
+        run_id,
+        len(levels),
+        confirmation_bars,
+    )
+
     results: List[Dict[str, Any]] = []
     for level in levels:
+        level_id = _summarise_level(level)
+        log.debug("%s | level_eval | level=%s", run_id, level_id)
         meta = _evaluate_level(df, level, confirmation_bars)
         if not meta:
+            log.debug("%s | level_eval_complete | level=%s | breakout=False", run_id, level_id)
             continue
 
         breakout_time = df.index[-1]
@@ -165,7 +250,9 @@ def pivot_breakout_rule(
                 **meta,
             }
         )
+        log.debug("%s | level_eval_complete | level=%s | breakout=True", run_id, level_id)
 
+    log.debug("%s | run_complete | signals=%d", run_id, len(results))
     return results
 
 
@@ -313,3 +400,4 @@ __all__ = [
     "pivot_signals_to_overlays",
     "register_pivot_indicator",
 ]
+


### PR DESCRIPTION
## Summary
- add detailed trace-aware logging to pivot level indicator initialisation, pivot detection, and level creation
- instrument pivot breakout rule with Grafana-friendly run and level identifiers plus reason codes for skipped signals
- expose helpers for consistent level summaries and run IDs consumed by the new logging

## Testing
- pytest tests/test_signals/test_pivot_breakout_rule.py

------
https://chatgpt.com/codex/tasks/task_e_68d1e322dd808331a1c0ccbbfdd95b2f