### PR TITLE
Ensure signal rules receive symbol context

### DIFF
--- a/portal/backend/service/indicator_service.py
+++ b/portal/backend/service/indicator_service.py
@@ -215,6 +215,14 @@ def overlays_for_instance(
 
     # fetch windowed OHLCV for overlay computation
     provider = AlpacaProvider()
+    logger.info(
+        "Preparing overlay data | indicator=%s | symbol=%s | interval=%s | start=%s | end=%s",
+        inst_id,
+        sym,
+        interval,
+        start,
+        end,
+    )
     ctx = DataContext(symbol=sym, start=start, end=end, interval=interval)
     df = provider.get_ohlcv(ctx)
     if df is None or df.empty:
@@ -264,6 +272,14 @@ def generate_signals_for_instance(
         raise ValueError("Stored indicator has no symbol and none was provided")
 
     provider = AlpacaProvider()
+    logger.info(
+        "Preparing signal data | indicator=%s | symbol=%s | interval=%s | start=%s | end=%s",
+        inst_id,
+        sym,
+        interval,
+        start,
+        end,
+    )
     ctx = DataContext(symbol=sym, start=start, end=end, interval=interval)
     df = provider.get_ohlcv(ctx)
     if df is None or df.empty:
@@ -271,11 +287,16 @@ def generate_signals_for_instance(
 
     rule_config: Dict[str, Any] = dict(config or {})
     rule_config.setdefault("pivot_breakout_confirmation_bars", 1)
+    rule_config.setdefault("symbol", sym)
 
     logger.info(
-        "Running signal rules for indicator %s (%s) with config=%s",
+        "Running signal rules for indicator %s (%s) | symbol=%s | interval=%s | start=%s | end=%s | config=%s",
         inst_id,
         getattr(inst, "NAME", inst.__class__.__name__),
+        sym,
+        interval,
+        start,
+        end,
         rule_config,
     )
 

--- a/tests/test_signals/test_signal_generator.py
+++ b/tests/test_signals/test_signal_generator.py
@@ -96,3 +96,24 @@ def test_build_signal_overlays_uses_registered_adapter():
     assert overlays == [{"kind": "custom", "label": "ok"}]
     assert called["signals"] == [dummy_signal]
     assert called["plot_df_shape"] == df.shape
+
+
+def test_run_indicator_rules_injects_symbol_into_context():
+    captured = {}
+
+    def rule(context, payload):
+        captured.update(context)
+        return []
+
+    indicator_type = "dummy_context"
+    register_indicator_rules(indicator_type, [rule])
+
+    class DummyFrame:
+        index = []
+        shape = (0, 0)
+
+    df = DummyFrame()
+
+    run_indicator_rules(indicator_type, df, symbol="NQ")
+
+    assert captured.get("symbol") == "NQ"


### PR DESCRIPTION
## Summary
- inject the resolved symbol into signal rule configuration so both rule execution and overlay building receive it
- log the symbol and chart timeframe when fetching data for overlays and signal runs to confirm they use the chart window
- add unit coverage ensuring the signal context exposes the provided symbol

## Testing
- pytest tests/test_signals/test_signal_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68d1e8bd8b548331b31e88b3ca19161e