### PR TITLE
Enhance pivot breakout overlays and chart UI

### DIFF
--- a/portal/frontend/src/chart/indicators/registry.js
+++ b/portal/frontend/src/chart/indicators/registry.js
@@ -2,7 +2,7 @@ import { PaneViewType } from '../paneViews/factory';
 
 const INDICATOR_PANEVIEWS = {
   default: [PaneViewType.TOUCH],
-  pivot_level: [PaneViewType.TOUCH],
+  pivot_level: [PaneViewType.SIGNAL_BUBBLE, PaneViewType.TOUCH],
   market_profile: [PaneViewType.VA_BOX, PaneViewType.TOUCH],
   trendline: [PaneViewType.SEGMENT, PaneViewType.TOUCH],
   vwap: [PaneViewType.POLYLINE, PaneViewType.TOUCH],
@@ -20,13 +20,19 @@ export function adaptPayload(type, payload, colorHex) {
   const boxes      = Array.isArray(payload?.boxes) ? payload.boxes : [];
   const segments   = Array.isArray(payload?.segments) ? payload.segments : [];
   const polylines  = Array.isArray(payload?.polylines) ? payload.polylines : [];
+  const bubbles    = Array.isArray(payload?.bubbles) ? payload.bubbles : [];
 
   const touchPoints = markersAll
     .filter(m => m?.subtype === 'touch' && typeof m?.price === 'number' && m?.time != null)
     .map(m => ({ time: m.time, price: Number(m.price), color: colorHex || m.color, size: m.size ?? 4 }));
 
-  const markers = markersAll.filter(m => m?.subtype !== 'touch')
+  const markers = markersAll
+    .filter(m => m?.subtype !== 'touch' && m?.subtype !== 'bubble')
     .map(m => ({ ...m, time: toSec(m.time) }));
+
+  const signalBubbles = bubbles
+    .concat(markersAll.filter(m => m?.subtype === 'bubble'))
+    .map(b => ({ ...b, time: toSec(b.time) }));
 
   // normalize times for new types
   const normSegments = segments.map(s => ({
@@ -38,5 +44,13 @@ export function adaptPayload(type, payload, colorHex) {
     points: (l.points || []).map(p => ({ time: toSec(p.time), price: Number(p.price) })),
   }));
 
-  return { priceLines, markers, touchPoints, boxes, segments: normSegments, polylines: normPolylines };
+  return {
+    priceLines,
+    markers,
+    touchPoints,
+    boxes,
+    segments: normSegments,
+    polylines: normPolylines,
+    bubbles: signalBubbles,
+  };
 }

--- a/portal/frontend/src/chart/paneViews/factory.js
+++ b/portal/frontend/src/chart/paneViews/factory.js
@@ -2,6 +2,7 @@ import { createTouchPaneView } from './touchPaneView';
 import { createVABoxPaneView } from './vaBoxPaneView';
 import { createSegmentPaneView } from './segmentPaneView';
 import { createPolylinePaneView } from './polylinePaneView';
+import { createSignalBubblePaneView } from './signalBubblePaneView';
 
 const toSec = (t) => (typeof t === 'number' && t > 2e10 ? Math.floor(t / 1000) : t);
 
@@ -10,6 +11,7 @@ export const PaneViewType = {
   VA_BOX: 'va_box',
   SEGMENT: 'segment',
   POLYLINE: 'polyline',
+  SIGNAL_BUBBLE: 'signal_bubble',
 };
 
 export class PaneViewManager {
@@ -27,6 +29,7 @@ export class PaneViewManager {
     else if (type === PaneViewType.VA_BOX)  view = createVABoxPaneView(this.ts, { extendRight: true, hatchOverlap: false, outlineFront: true });
     else if (type === PaneViewType.SEGMENT) view = createSegmentPaneView(this.ts);
     else if (type === PaneViewType.POLYLINE) view = createPolylinePaneView(this.ts);
+    else if (type === PaneViewType.SIGNAL_BUBBLE) view = createSignalBubblePaneView(this.ts);
     else throw new Error(`Unknown pane view: ${type}`);
     const base = view.defaultOptions?.() ?? {};
     const s = this.chart.addCustomSeries(view, {
@@ -44,6 +47,7 @@ export class PaneViewManager {
       if (type === PaneViewType.VA_BOX)   { view.setBoxes?.([]);  this.series.get(type)?.setData([]); }
       if (type === PaneViewType.SEGMENT)  { view.setSegments?.([]); this.series.get(type)?.setData([]); }
       if (type === PaneViewType.POLYLINE) { view.setPolylines?.([]); this.series.get(type)?.setData([]); }
+      if (type === PaneViewType.SIGNAL_BUBBLE) { view.setBubbles?.([]); this.series.get(type)?.setData([]); }
     }
   }
   destroy() {
@@ -74,6 +78,24 @@ export class PaneViewManager {
        .filter(Number.isFinite).sort((a,b)=>a-b)
        .map(t => ({ time: t, originalData: {} }));
     this.series.get(PaneViewType.POLYLINE).setData(times);
+  }
+  setSignalBubbles(bubs){ this.ensure(PaneViewType.SIGNAL_BUBBLE);
+    const normalized = (bubs || []).map(b => ({ ...b, time: toSec(b.time) }));
+    this.views.get(PaneViewType.SIGNAL_BUBBLE).setBubbles(normalized);
+
+    const grouped = new Map();
+    for (const bubble of normalized) {
+      const time = bubble?.time;
+      if (!Number.isFinite(time)) continue;
+      if (!grouped.has(time)) grouped.set(time, []);
+      grouped.get(time).push(bubble);
+    }
+
+    const data = [...grouped.entries()]
+      .sort((a,b) => a[0] - b[0])
+      .map(([time, entries]) => ({ time, originalData: { bubbles: entries } }));
+
+    this.series.get(PaneViewType.SIGNAL_BUBBLE).setData(data);
   }
     setTouchPoints(points) {
     // points: [{ time, price, color, size }]

--- a/portal/frontend/src/chart/paneViews/signalBubblePaneView.js
+++ b/portal/frontend/src/chart/paneViews/signalBubblePaneView.js
@@ -1,0 +1,225 @@
+const toSec = (t) => (typeof t === 'number' && t > 2e10 ? Math.floor(t / 1000) : t);
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const hexToRgba = (hex, alpha) => {
+  if (typeof hex !== 'string') return null;
+  const value = hex.trim().replace('#', '');
+  if (value.length !== 6) return null;
+  const r = Number.parseInt(value.slice(0, 2), 16);
+  const g = Number.parseInt(value.slice(2, 4), 16);
+  const b = Number.parseInt(value.slice(4, 6), 16);
+  if ([r, g, b].some((n) => Number.isNaN(n))) return null;
+  const a = Math.min(Math.max(alpha, 0), 1);
+  return `rgba(${r},${g},${b},${a.toFixed(2)})`;
+};
+
+const drawRoundedBubble = (ctx, x, y, width, height, radius, pointer, accent, background, shadow) => {
+  const r = Math.min(radius, width / 2, height / 2);
+  const pointerWidth = pointer.width;
+  const pointerHeight = pointer.height;
+  const pointerHalf = pointerWidth / 2;
+  const pointerBase = clamp(pointer.baseX, x + pointerHalf, x + width - pointerHalf);
+  const direction = pointer.direction;
+
+  ctx.save();
+  ctx.beginPath();
+
+  ctx.moveTo(x + r, y);
+
+  if (direction === 'up') {
+    ctx.lineTo(pointerBase - pointerHalf, y);
+    ctx.lineTo(pointerBase, y - pointerHeight);
+    ctx.lineTo(pointerBase + pointerHalf, y);
+  }
+
+  ctx.lineTo(x + width - r, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+  ctx.lineTo(x + width, y + height - r);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+
+  if (direction === 'down') {
+    ctx.lineTo(pointerBase + pointerHalf, y + height);
+    ctx.lineTo(pointerBase, y + height + pointerHeight);
+    ctx.lineTo(pointerBase - pointerHalf, y + height);
+  }
+
+  ctx.lineTo(x + r, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+
+  ctx.closePath();
+
+  if (shadow) {
+    ctx.shadowColor = shadow;
+    ctx.shadowBlur = 12;
+    ctx.shadowOffsetY = 6;
+  }
+
+  ctx.fillStyle = background;
+  ctx.fill();
+  ctx.shadowColor = 'transparent';
+  ctx.lineWidth = 1.5;
+  ctx.strokeStyle = accent;
+  ctx.stroke();
+  ctx.restore();
+};
+
+const drawAccentBar = (ctx, x, y, width, accentColor) => {
+  ctx.save();
+  ctx.fillStyle = accentColor;
+  ctx.fillRect(x, y, width, 3);
+  ctx.restore();
+};
+
+export function createSignalBubblePaneView(timeScaleApi) {
+  let bubbles = [];
+
+  const renderer = {
+    draw(target, priceToCoordinate) {
+      const { context: ctx, horizontalPixelRatio: hpr, verticalPixelRatio: vpr, bitmapSize } =
+        target.useBitmapCoordinateSpace(({ context, horizontalPixelRatio, verticalPixelRatio, bitmapSize: size }) => ({
+          context,
+          horizontalPixelRatio,
+          verticalPixelRatio,
+          bitmapSize: size,
+        }));
+
+      if (!ctx) return;
+
+      const widthPx = bitmapSize?.width ?? ctx.canvas.width;
+      const heightPx = bitmapSize?.height ?? ctx.canvas.height;
+
+      const padX = 16 * hpr;
+      const padY = 12 * vpr;
+      const pointerHeight = 14 * vpr;
+      const pointerWidth = 24 * hpr;
+      const radius = 14 * Math.min(hpr, vpr);
+
+      ctx.save();
+      ctx.textBaseline = 'top';
+
+      for (const bubble of bubbles) {
+        const rawTime = toSec(bubble.time);
+        const px = timeScaleApi.timeToCoordinate(rawTime);
+        if (px == null) continue;
+
+        const py = priceToCoordinate(Number(bubble.price));
+        if (py == null) continue;
+
+        const accent = bubble.accentColor ?? '#38bdf8';
+        const background = bubble.backgroundColor ?? hexToRgba(accent, 0.18) ?? 'rgba(30,41,59,0.85)';
+        const textColor = bubble.textColor ?? '#f8fafc';
+        const shadow = hexToRgba(accent, 0.45);
+
+        const label = bubble.label ?? 'Signal';
+        const detail = bubble.detail ?? '';
+        const meta = bubble.meta ?? '';
+
+        const direction = bubble.direction === 'below' ? 'below' : 'above';
+
+        const headingFontSize = 13;
+        const bodyFontSize = 11;
+
+        ctx.font = `600 ${headingFontSize * vpr}px "Inter", "Segoe UI", sans-serif`;
+        const headingWidth = ctx.measureText(label).width;
+        const headingHeight = headingFontSize * 1.3 * vpr;
+
+        ctx.font = `500 ${bodyFontSize * vpr}px "Inter", "Segoe UI", sans-serif`;
+        const detailWidth = detail ? ctx.measureText(detail).width : 0;
+        const metaWidth = meta ? ctx.measureText(meta).width : 0;
+        const bodyHeight = (detail ? bodyFontSize * 1.25 * vpr : 0) + (meta ? bodyFontSize * 1.25 * vpr : 0);
+
+        const textWidth = Math.max(headingWidth, detailWidth, metaWidth);
+        const textHeight = headingHeight + bodyHeight;
+
+        const bubbleWidth = textWidth + padX * 2;
+        const bubbleHeight = textHeight + padY * 2;
+
+        const pointerDir = direction === 'above' ? 'down' : 'up';
+
+        let bubbleX = px * hpr - bubbleWidth / 2;
+        const minX = 12 * hpr;
+        const maxX = widthPx - bubbleWidth - 12 * hpr;
+        bubbleX = clamp(bubbleX, minX, Math.max(minX, maxX));
+
+        let bubbleY;
+        if (direction === 'above') {
+          bubbleY = py * vpr - pointerHeight - bubbleHeight;
+        } else {
+          bubbleY = py * vpr + pointerHeight;
+        }
+
+        const minY = 12 * vpr;
+        const maxY = heightPx - bubbleHeight - 12 * vpr;
+        bubbleY = clamp(bubbleY, minY, Math.max(minY, maxY));
+
+        let pointerBaseX = px * hpr;
+        const pointerClampLeft = bubbleX + pointerWidth * 0.6;
+        const pointerClampRight = bubbleX + bubbleWidth - pointerWidth * 0.6;
+        pointerBaseX = clamp(pointerBaseX, pointerClampLeft, pointerClampRight);
+
+        const pointer = {
+          width: pointerWidth,
+          height: pointerHeight,
+          baseX: pointerBaseX,
+          direction: pointerDir === 'down' ? 'down' : 'up',
+        };
+
+        drawRoundedBubble(ctx, bubbleX, bubbleY, bubbleWidth, bubbleHeight, radius, pointer, accent, background, shadow);
+        if (pointer.direction === 'down') {
+          drawAccentBar(ctx, bubbleX, bubbleY, bubbleWidth, accent);
+        } else {
+          drawAccentBar(ctx, bubbleX, bubbleY + bubbleHeight - 3, bubbleWidth, accent);
+        }
+
+        ctx.fillStyle = textColor;
+
+        let cursorY = bubbleY + padY;
+        ctx.font = `600 ${headingFontSize * vpr}px "Inter", "Segoe UI", sans-serif`;
+        ctx.fillText(label, bubbleX + padX, cursorY);
+        cursorY += headingHeight;
+
+        ctx.font = `500 ${bodyFontSize * vpr}px "Inter", "Segoe UI", sans-serif`;
+        if (detail) {
+          ctx.fillStyle = textColor;
+          ctx.fillText(detail, bubbleX + padX, cursorY);
+          cursorY += bodyFontSize * 1.25 * vpr;
+        }
+
+        if (meta) {
+          ctx.fillStyle = hexToRgba(accent, 0.9) ?? accent;
+          ctx.fillText(meta, bubbleX + padX, cursorY);
+        }
+
+        ctx.beginPath();
+        const pointerTipY = direction === 'above'
+          ? bubbleY + bubbleHeight + pointerHeight
+          : bubbleY - pointerHeight;
+        const pointerTipX = pointerBaseX;
+        ctx.fillStyle = accent;
+        ctx.arc(pointerTipX, pointerTipY, 3.5 * Math.min(hpr, vpr), 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      ctx.restore();
+    },
+    drawBackground() {},
+    hitTest() { return null; },
+  };
+
+  return {
+    renderer: () => renderer,
+    update: () => {},
+    priceValueBuilder: () => [NaN, NaN, NaN],
+    isWhitespace: (item) => !(item?.originalData?.bubbles?.length),
+    defaultOptions() {
+      return { priceLineVisible: false, lastValueVisible: false, crosshairMarkerVisible: false };
+    },
+    destroy: () => {},
+    setBubbles(next) {
+      bubbles = Array.isArray(next) ? next : [];
+    },
+  };
+}

--- a/portal/frontend/src/components/ChartComponent/ChartComponent.jsx
+++ b/portal/frontend/src/components/ChartComponent/ChartComponent.jsx
@@ -33,6 +33,7 @@ export const ChartComponent = ({ chartId }) => {
     new Date()
   ]);
   const [dataLoading, setDataLoading] = useState(false);
+  const [rangeWarning, setRangeWarning] = useState(null);
 
   // Refs for chart and DOM.
   const chartContainerRef = useRef(null);
@@ -41,6 +42,7 @@ export const ChartComponent = ({ chartId }) => {
   const seededRef = useRef(false); // ensure we seed only once
   const pvMgrRef = useRef(null);
   const lastBarRef = useRef(null);
+  const timeframeWarningRef = useRef(null);
 
     // Overlay resource handles.
   const overlayHandlesRef = useRef({ priceLines: [] });
@@ -131,6 +133,12 @@ export const ChartComponent = ({ chartId }) => {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  useEffect(() => () => {
+    if (timeframeWarningRef.current) {
+      clearTimeout(timeframeWarningRef.current);
+    }
   }, []);
 
   const applySymbol = (sym) => { setSymbol(sym); handleApply(); };
@@ -235,6 +243,7 @@ export const ChartComponent = ({ chartId }) => {
     const markers = [];
     const touchPoints = [];
     const boxes = [];
+    const signalBubbles = [];
     const allSegments = [];
     const allPolylines = [];
 
@@ -245,9 +254,6 @@ export const ChartComponent = ({ chartId }) => {
 
       const paneViews = getPaneViewsFor(type);
       const norm = adaptPayload(type, payload, color);
-
-      // Norm
-      console.log("Overlay", { type, color, paneViews, norm });
 
       // 3a) Price lines.
       if (Array.isArray(payload.price_lines)) {
@@ -266,6 +272,13 @@ export const ChartComponent = ({ chartId }) => {
 
       // 3b) Markers.
       markers.push(...norm.markers);
+
+      if (Array.isArray(norm.bubbles) && norm.bubbles.length) {
+        signalBubbles.push(...norm.bubbles.map(b => ({
+          ...b,
+          accentColor: b.accentColor ?? color,
+        })));
+      }
 
       // 3c) Touch points.
       if (paneViews.includes('touch') && norm.touchPoints?.length) {
@@ -290,11 +303,9 @@ export const ChartComponent = ({ chartId }) => {
       }
 
       if (paneViews.includes('segment') && norm.segments?.length) {
-        console.log("Adding segments", norm.segments);
         allSegments.push(...norm.segments);
       }
       if (paneViews.includes('polyline') && norm.polylines?.length) {
-        console.log("Adding polylines", norm.polylines);
         allPolylines.push(...norm.polylines);
       }
     }
@@ -320,52 +331,13 @@ export const ChartComponent = ({ chartId }) => {
       overlayHandlesRef.current.markersApi.setMarkers(markers);
       
 
-      console.log("Custom overlays", { touchPoints: grouped, boxes, allSegments, allPolylines });
       pvMgrRef.current?.setTouchPoints(touchPoints);
       pvMgrRef.current?.setVABlocks(boxes);
       pvMgrRef.current?.setSegments(allSegments);
       pvMgrRef.current?.setPolylines(allPolylines);
+      pvMgrRef.current?.setSignalBubbles(signalBubbles);
 
       // --- C: VWAP vs Candles coverage + coordinate check ---
-      const ts = chartRef.current.timeScale();
-      const s = seriesRef.current;
-      const toSec = t => (typeof t === 'number' && t > 2e10 ? Math.floor(t/1000) : t);
-
-      // last candle (from the ref set in loadChartData)
-      const c = lastBarRef.current;
-      const cTime = typeof c?.time === 'number' ? c.time : c?.time?.timestamp;
-      const cClose = Number(c?.close);
-
-      // last vwap point across ALL polylines
-      const vPts = (allPolylines || [])
-        .flatMap(l => (l.points || []).map(p => ({ t: toSec(p.time), p: +p.price })))
-        .filter(o => Number.isFinite(o.t) && Number.isFinite(o.p))
-        .sort((a,b) => a.t - b.t);
-      const vLast = vPts.at(-1);
-
-      // fallbacks if no candle ref yet
-      const vr = ts.getVisibleRange?.();
-      const vrTo = (vr?.to ?? cTime);
-
-      // log both time/price and pixel coords
-      console.log('[CHK] last candle', {
-        t: cTime ?? vrTo,
-        iso: (cTime ?? vrTo) ? new Date((cTime ?? vrTo) * 1000).toISOString() : null,
-        close: cClose,
-        x: cTime != null ? ts.timeToCoordinate(cTime) : (vrTo != null ? ts.timeToCoordinate(vrTo) : null),
-        y: Number.isFinite(cClose) ? s.priceToCoordinate(cClose) : null,
-      });
-
-      console.log('[CHK] last vwap', {
-        t: vLast?.t,
-        iso: vLast ? new Date(vLast.t * 1000).toISOString() : null,
-        p: vLast?.p,
-        x: vLast ? ts.timeToCoordinate(vLast.t) : null,
-        y: vLast ? s.priceToCoordinate(vLast.p) : null,
-        nPts: vPts.length,
-      });
-
-
       // seriesRef.current.setData(touch)
     } catch (e) {
       error('setMarkers failed', e);
@@ -377,6 +349,7 @@ export const ChartComponent = ({ chartId }) => {
       markers: markers.length,
       touchPoints: touchPoints.length,
       boxes: boxes.length,
+      bubbles: signalBubbles.length,
       segments: allSegments.length,
       polylines: allPolylines.length,
     });
@@ -392,12 +365,24 @@ export const ChartComponent = ({ chartId }) => {
 
   // Apply handler.
   const handleApply = useCallback(() => {
+    const [start, end] = dateRange || [];
+    const maxWindowMs = 90 * 24 * 60 * 60 * 1000;
+    const windowMs = start && end ? Math.abs(end.getTime() - start.getTime()) : 0;
+    if (windowMs > maxWindowMs) {
+      warn('apply_blocked_range', { chartId, symbol, interval, windowMs });
+      setRangeWarning('Please choose a window of 90 days or less before applying.');
+      if (timeframeWarningRef.current) clearTimeout(timeframeWarningRef.current);
+      timeframeWarningRef.current = setTimeout(() => setRangeWarning(null), 5000);
+      return;
+    }
+
+    setRangeWarning(null);
     info('apply', { chartId, symbol, interval, dateRange });
     syncOverlays([]); // clear overlays on apply
     updateChart?.(chartId, { symbol, interval, dateRange });
     loadChartData();
     bumpRefresh?.(chartId);
-  }, [info, loadChartData, updateChart, bumpRefresh, chartId, symbol, interval, dateRange]);
+  }, [info, loadChartData, updateChart, bumpRefresh, chartId, symbol, interval, dateRange, warn]);
 
   function useBusyDelay(busy, ms=250){
     const [show,setShow]=useState(false);
@@ -411,33 +396,41 @@ export const ChartComponent = ({ chartId }) => {
   return (
     <>
 
-      {/* 90-day note */}
-      <div className="mb-2">
-        <span className="inline-flex items-center rounded-md bg-amber-500/10 px-2 py-1 text-xs font-medium text-amber-400 ring-1 ring-inset ring-amber-500/20">
-          ⚠️Timeframe max is 90 days
-        </span>
+      <div className="space-y-3 mb-4">
+        {rangeWarning && (
+          <div className="flex items-center gap-2 rounded-xl border border-amber-400/50 bg-amber-500/15 px-3 py-2 text-sm text-amber-100 shadow-lg shadow-amber-900/40">
+            <span className="text-lg">⚠️</span>
+            <span className="font-medium">{rangeWarning}</span>
+          </div>
+        )}
+
+        <div className="rounded-2xl border border-neutral-700/60 bg-neutral-900/70 p-4 shadow-xl shadow-black/40 backdrop-blur">
+          <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+            <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-end">
+              <TimeframeSelect selected={interval} onChange={setInterval} />
+              <SymbolInput value={symbol} onChange={setSymbol} />
+              <DateRangePickerComponent dateRange={dateRange} setDateRange={setDateRange} />
+            </div>
+            <button
+              className="inline-flex items-center justify-center gap-2 self-start rounded-xl bg-gradient-to-r from-indigo-500/80 to-sky-500/80 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-sky-900/40 transition hover:from-indigo-400 hover:to-sky-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+              onClick={handleApply}
+            >
+              <span>Apply changes</span>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-5 w-5">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m6-6H6" />
+              </svg>
+            </button>
+          </div>
+        </div>
       </div>
 
-      <div className="flex items-end space-x-4">
-        <TimeframeSelect selected={interval} onChange={setInterval} />
-        <SymbolInput value={symbol} onChange={setSymbol} />
-        <DateRangePickerComponent dateRange={dateRange} setDateRange={setDateRange} />
-        <button
-          className="mt-5.5 self-center border border-neutral-600 rounded-md p-2 hover:bg-neutral-700 transition-colors cursor-pointer"
-          onClick={handleApply}
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
-          </svg>
-        </button>
-      </div>
-      <div className="flex space-x-4 mt-5">
-        <div className="relative flex-1 rounded-lg overflow-hidden bg-gray-800 h-[550px]">
+      <div className="flex space-x-4">
+        <div className="relative flex-1 h-[560px] overflow-hidden rounded-3xl border border-neutral-800/70 bg-gradient-to-b from-neutral-950/90 to-neutral-900/70 shadow-2xl shadow-black/40">
           <div ref={chartContainerRef} className="h-full w-full bg-transparent" />
           <button
             type="button"
             onClick={() => setPalOpen(true)}
-            className="h-9 px-3 rounded-md border border-neutral-600 bg-neutral-800/70 text-neutral-200 hover:bg-neutral-700"
+            className="absolute left-4 top-4 inline-flex h-9 items-center justify-center rounded-lg border border-neutral-700/70 bg-neutral-900/70 px-3 text-sm font-medium text-neutral-200 shadow-lg shadow-black/30 backdrop-blur hover:bg-neutral-800"
             title="Open symbol presets (/)"
           >
             Presets

--- a/portal/frontend/src/components/ChartComponent/DateTimePickerComponent.jsx
+++ b/portal/frontend/src/components/ChartComponent/DateTimePickerComponent.jsx
@@ -24,51 +24,52 @@ export function DateRangePickerComponent({
   }, [startDate, endDate]);
 
   return (
-    <div className="flex items-center space-x-3">
-      {/* Start Date Picker */}
-      <div className="flex flex-col">
-        <label htmlFor="startDatePicker" className="text-sm text-neutral-500">Start Date/Time</label>
-        <Flatpickr
-          id="startDatePicker"
-          ref={datePickerRef}
-          value={startDate}
-          onChange={([date]) => setDateRange([date, endDate])}
-          options={{
-            dateFormat: "Y-m-d H:i",
-            maxDate: "today",
-            minDate: "2020-01-01",
-            altInput: true,
-            altFormat: "Y-m-d H:i",
-            allowInput: true,
-            enableTime: true,
-          }}
-          className="self-end w-fit bg-neutral-800 border border-neutral-600 rounded-md shadow-sm px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        />
-      </div>
+    <div className="flex flex-col gap-2 min-w-[19rem]">
+      <span className="text-[11px] uppercase tracking-[0.2em] text-neutral-400">Date range</span>
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-col gap-1">
+          <span className="text-xs text-neutral-500">Start</span>
+          <Flatpickr
+            id="startDatePicker"
+            ref={datePickerRef}
+            value={startDate}
+            onChange={([date]) => setDateRange([date, endDate])}
+            options={{
+              dateFormat: "Y-m-d H:i",
+              maxDate: "today",
+              minDate: "2020-01-01",
+              altInput: true,
+              altFormat: "Y-m-d H:i",
+              allowInput: true,
+              enableTime: true,
+            }}
+            className="w-48 rounded-lg border border-neutral-700/70 bg-neutral-900/70 px-3 py-2 text-sm text-neutral-100 shadow-inner shadow-black/30 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+          />
+        </div>
 
-      <div className="flex items-center">
-        <span className="text-neutral-400 mt-4">to</span>
-      </div>
+        <div className="mb-1 flex h-8 items-center justify-center rounded-full border border-neutral-700/70 px-3 text-xs uppercase tracking-[0.2em] text-neutral-400">
+          to
+        </div>
 
-      {/* End Date Picker */}
-      <div className="flex flex-col">
-        <label htmlFor="endDatePicker" className="text-sm text-neutral-500">End Date/Time</label>
-        <Flatpickr
-          id="endDatePicker"
-          ref={datePickerRef}
-          value={endDate}
-          onChange={([date]) => setDateRange([startDate, date])}
-          options={{
-            dateFormat: "Y-m-d H:i",
-            minDate: "2020-01-01",
-            maxDate: new Date(Date.now() + 5 * 60),
-            altInput: true,
-            altFormat: "Y-m-d H:i",
-            allowInput: true,
-            enableTime: true,
-          }}
-          className="self-end w-fit bg-neutral-800 border border-neutral-600 rounded-md shadow-sm px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        />
+        <div className="flex flex-col gap-1">
+          <span className="text-xs text-neutral-500">End</span>
+          <Flatpickr
+            id="endDatePicker"
+            ref={datePickerRef}
+            value={endDate}
+            onChange={([date]) => setDateRange([startDate, date])}
+            options={{
+              dateFormat: "Y-m-d H:i",
+              minDate: "2020-01-01",
+              maxDate: new Date(Date.now() + 5 * 60),
+              altInput: true,
+              altFormat: "Y-m-d H:i",
+              allowInput: true,
+              enableTime: true,
+            }}
+            className="w-48 rounded-lg border border-neutral-700/70 bg-neutral-900/70 px-3 py-2 text-sm text-neutral-100 shadow-inner shadow-black/30 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+          />
+        </div>
       </div>
     </div>
   );

--- a/portal/frontend/src/components/ChartComponent/TimeframeSelectComponent.jsx
+++ b/portal/frontend/src/components/ChartComponent/TimeframeSelectComponent.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React from 'react';
 
 /**
  * Available timeframes:
@@ -9,9 +9,9 @@ const options = [
   { label: '5 Minutes', value: '5m' },
   { label: '15 Minutes', value: '15m' },
   { label: '30 Minutes', value: '30m' },
-  { label: '1 Hour', value: '1h' },
-  { label: '4 Hours', value: '4h' },
-  { label: '1 Day', value: '1d' },
+  { label: '1 Hour', value: '1h', featured: true },
+  { label: '4 Hours', value: '4h', featured: true },
+  { label: '1 Day', value: '1d', featured: true },
   { label: '1 Week', value: '1w' },
   { label: '1 Month', value: '1M' },
 ];
@@ -23,56 +23,35 @@ const options = [
  * @param {function} props.onChange - Callback when a timeframe is selected
  * @param {string} [props.placeholder='Select timeframe...'] - Placeholder text
  */
-export function TimeframeSelect({ selected, onChange, placeholder = 'Select timeframe...' }) {
-  const [isOpen, setIsOpen] = useState(false);
-  const containerRef = useRef(null);
-
-  // Close dropdown on outside click
-  useEffect(() => {
-    const handleClickOutside = (e) => {
-      if (containerRef.current && !containerRef.current.contains(e.target)) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  const toggleOpen = () => setIsOpen(prev => !prev);
-
-  const handleSelect = (option) => {
-    onChange(option.value);
-    setIsOpen(false);
-  };
-
-  const selectedOption = options.find(o => o.value === selected);
-
+export function TimeframeSelect({ selected, onChange }) {
   return (
-    <div ref={containerRef} className="relative inline-block w-40">
-      <span className="text-neutral-500 text-sm"> Timeframe </span>
-      <button
-        type="button"
-        onClick={toggleOpen}
-        className="w-full text-left bg-neutral-800 border border-neutral-600 rounded-md shadow-sm px-2 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-      >
-        {selectedOption ? selectedOption.label : placeholder}
-        <span className="float-right ml-2">▽</span>
-        {/* ▼◿⌟ⅴ∇∨⋁⋎⨈⩔⩒⩖⩛⩢ */}
-      </button>
+    <div className="flex flex-col gap-2 min-w-[13rem]">
+      <span className="text-[11px] uppercase tracking-[0.2em] text-neutral-400">Timeframe</span>
+      <div className="flex flex-wrap gap-2">
+        {options.map(option => {
+          const isActive = option.value === selected;
+          const baseClass = 'rounded-lg border px-3 py-1.5 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2';
+          const activeClass = option.featured
+            ? 'border-sky-400/90 bg-sky-500/20 text-sky-100 shadow-lg shadow-sky-900/40'
+            : 'border-indigo-400/80 bg-indigo-500/20 text-indigo-100 shadow';
+          const inactiveClass = option.featured
+            ? 'border-neutral-700/70 bg-neutral-900/70 text-neutral-200 hover:border-sky-400/70 hover:text-sky-200'
+            : 'border-neutral-700/60 bg-neutral-900/60 text-neutral-300 hover:border-indigo-400/60 hover:text-indigo-200';
 
-      {isOpen && (
-        <ul className="absolute z-10 mt-1 w-full bg-neutral-800 border border-neutral-600 rounded-md shadow-lg max-h-60 overflow-auto">
-          {options.map(option => (
-            <li
+          return (
+            <button
               key={option.value}
-              onClick={() => handleSelect(option)}
-              className="px-4 py-2 hover:bg-indigo-600 hover:text-white cursor-pointer"
+              type="button"
+              title={option.label}
+              aria-pressed={isActive}
+              onClick={() => onChange(option.value)}
+              className={`${baseClass} ${isActive ? activeClass : inactiveClass}`}
             >
-              {option.label}
-            </li>
-          ))}
-        </ul>
-      )}
+              {option.value.toUpperCase()}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -80,15 +59,26 @@ export function TimeframeSelect({ selected, onChange, placeholder = 'Select time
 
 export function SymbolInput({ value, onChange, placeholder = 'Symbol' }) {
   return (
-    <div className="flex flex-col">
-      <span className="text-neutral-500 text-sm"> Symbol </span>
-      <input
-        type="text"
-        className="w-40 bg-neutral-800 border border-neutral-600 rounded-md shadow-sm px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-      />
+    <div className="flex flex-col gap-2 min-w-[10rem]">
+      <span className="text-[11px] uppercase tracking-[0.2em] text-neutral-400">Symbol</span>
+      <div className="relative flex items-center">
+        <span className="pointer-events-none absolute left-3 text-neutral-500">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-4 w-4">
+            <path strokeLinecap="round" strokeLinejoin="round" d="m19 19-3.5-3.5m1-4.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0Z" />
+          </svg>
+        </span>
+        <input
+          type="text"
+          inputMode="text"
+          spellCheck={false}
+          autoCapitalize="characters"
+          autoComplete="off"
+          className="w-40 rounded-lg border border-neutral-700/70 bg-neutral-900/70 py-2 pl-9 pr-3 text-sm font-semibold uppercase tracking-wide text-neutral-100 shadow-inner shadow-black/30 outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-500/50"
+          value={value}
+          onChange={(e) => onChange(e.target.value.toUpperCase())}
+          placeholder={placeholder}
+        />
+      </div>
     </div>
   );
 }

--- a/src/signals/rules/pivot.py
+++ b/src/signals/rules/pivot.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 import pandas as pd
 
@@ -305,6 +305,50 @@ _BREAKOUT_COLORS = {
 }
 
 
+def _hex_to_rgb(color: str) -> Optional[Tuple[int, int, int]]:
+    """Return RGB tuple for a hex color string."""
+
+    if not isinstance(color, str):
+        return None
+
+    value = color.strip().lstrip("#")
+    if len(value) != 6:
+        return None
+
+    try:
+        r = int(value[0:2], 16)
+        g = int(value[2:4], 16)
+        b = int(value[4:6], 16)
+    except ValueError:  # pragma: no cover - defensive guard
+        return None
+
+    return r, g, b
+
+
+def _rgba_from_hex(color: str, alpha: float) -> Optional[str]:
+    """Convert a hex color to an rgba() string with the provided alpha."""
+
+    rgb = _hex_to_rgb(color)
+    if rgb is None:
+        return None
+
+    r, g, b = rgb
+    a = min(max(alpha, 0.0), 1.0)
+    return f"rgba({r},{g},{b},{a:.2f})"
+
+
+def _readable_text_color(color: str) -> str:
+    """Pick a contrasting text color for the provided background color."""
+
+    rgb = _hex_to_rgb(color)
+    if rgb is None:
+        return "#0f172a"
+
+    r, g, b = rgb
+    luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+    return "#0f172a" if luminance > 0.55 else "#f8fafc"
+
+
 def pivot_signals_to_overlays(
     signals: Sequence[BaseSignal],
     plot_df: "pd.DataFrame",
@@ -315,10 +359,7 @@ def pivot_signals_to_overlays(
     if not signals:
         return []
 
-    markers: List[Dict[str, Any]] = []
-    price_lines: List[Dict[str, Any]] = []
-
-    index = getattr(plot_df, "index", None)
+    bubbles: List[Dict[str, Any]] = []
 
     for signal in signals:
         metadata = signal.metadata or {}
@@ -331,52 +372,44 @@ def pivot_signals_to_overlays(
 
         marker_time = _to_unix_seconds(signal.time)
         level_kind = str(metadata.get("level_kind", "pivot")).capitalize()
-        marker_position = "belowBar" if breakout_direction == "above" else "aboveBar"
-        marker_shape = "triangleUp" if breakout_direction == "above" else "triangleDown"
+        if level_kind == "Resistance":
+            marker_label = "Resistance breakout"
+        elif level_kind == "Support":
+            marker_label = "Support breakdown"
+        else:
+            marker_label = f"{level_kind} breakout"
 
-        markers.append(
-            {
-                "time": marker_time,
-                "price": float(level_price),
-                "color": color,
-                "position": marker_position,
-                "shape": marker_shape,
-                "text": f"{level_kind} breakout",
-                "subtype": "signal",
-            }
-        )
+        trigger_close = metadata.get("trigger_close")
+        level_tf = metadata.get("level_timeframe")
+        detail_prefix = "Closed above" if breakout_direction == "above" else "Closed below"
+        detail = None
+        if trigger_close is not None:
+            detail = f"{detail_prefix} {level_price:.2f} at {trigger_close:.2f}"
+        timeframe_badge = None
+        if level_tf:
+            timeframe_badge = f"TF {level_tf}"
 
-        start_time = metadata.get("breakout_start")
-        origin_time = _to_unix_seconds(start_time)
-        if origin_time is None and index is not None and len(index):
-            origin_time = _to_unix_seconds(index[0])
-        if origin_time is None:
-            origin_time = marker_time
-        end_time = marker_time
+        bubble_payload: Dict[str, Any] = {
+            "time": marker_time,
+            "price": float(level_price),
+            "label": marker_label,
+            "detail": detail,
+            "meta": timeframe_badge,
+            "accentColor": color,
+            "backgroundColor": _rgba_from_hex(color, 0.2) or "rgba(30,41,59,0.75)",
+            "textColor": _readable_text_color(color),
+            "direction": breakout_direction,
+            "subtype": "bubble",
+        }
+        bubbles.append(bubble_payload)
 
-        if origin_time and end_time and origin_time > end_time:
-            origin_time, end_time = end_time, origin_time
-
-        price_lines.append(
-            {
-                "price": float(level_price),
-                "color": color,
-                "lineStyle": 0,
-                "lineWidth": 2,
-                "axisLabelVisible": True,
-                "title": f"{level_kind} lvl",
-                "extend": "none",
-                "originTime": origin_time,
-                "endTime": end_time,
-            }
-        )
-
-    if not markers and not price_lines:
+    if not bubbles:
         return []
 
     payload = {
-        "price_lines": price_lines,
-        "markers": markers,
+        "price_lines": [],
+        "markers": [],
+        "bubbles": bubbles,
     }
 
     return [


### PR DESCRIPTION
## Summary
- replace pivot breakout price markers with richer bubble overlays and remove redundant price lines
- add a dedicated signal bubble pane view and refresh chart controls with preset timeframe buttons and improved styling
- gate timeframe requests longer than 90 days with inline warnings for better UX feedback

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*
- npm run lint *(fails: existing lint violations in generated/vendor files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f4db2028833186962088266e6202