### PR TITLE
Fix VA boxes to stay anchored while zooming

### DIFF
--- a/portal/frontend/src/chart/paneViews/factory.js
+++ b/portal/frontend/src/chart/paneViews/factory.js
@@ -56,12 +56,22 @@ export class PaneViewManager {
   }
 
   setVABlocks(boxes){ this.ensure(PaneViewType.VA_BOX);
-    this.views.get(PaneViewType.VA_BOX).setBoxes(boxes || []);
+    const view = this.views.get(PaneViewType.VA_BOX);
+    view.setBoxes(boxes || []);
     // seed unique ascending times
     const times = [...new Set((boxes||[]).flatMap(b => [toSec(b.x1), toSec(b.x2)]))]
       .filter(Number.isFinite).sort((a,b)=>a-b)
       .map(t => ({ time: t, originalData: {} }));
-    this.series.get(PaneViewType.VA_BOX).setData(times);
+    const series = this.series.get(PaneViewType.VA_BOX);
+    series.setData(times);
+
+    const rightEdge = Math.max(
+      ...((boxes || [])
+        .map(b => toSec(b.x2))
+        .filter((t) => typeof t === 'number' && Number.isFinite(t))),
+      -Infinity,
+    );
+    view.setRightEdgeTime(Number.isFinite(rightEdge) ? rightEdge : null);
   }
   setSegments(segs){ this.ensure(PaneViewType.SEGMENT);
     this.views.get(PaneViewType.SEGMENT).setSegments(segs || []);

--- a/portal/frontend/src/chart/paneViews/vaBoxPaneView.js
+++ b/portal/frontend/src/chart/paneViews/vaBoxPaneView.js
@@ -17,15 +17,19 @@ export function createVABoxPaneView(timeScaleApi, opts = {}) {
     const pxRects = [];
 
     for (const b of boxes) {
-      const xLeft  = timeScaleApi.timeToCoordinate(toSec(b.x1)) * hpr;
+      const leftCoord = timeScaleApi.timeToCoordinate(toSec(b.x1));
+      const xLeft = leftCoord != null ? leftCoord * hpr : null;
       let xRight;
-      if (!extendRight) {
-        xRight = timeScaleApi.timeToCoordinate(toSec(b.x2)) * hpr;
+      const hasExplicitRight = b?.x2 != null;
+      if (!extendRight || hasExplicitRight) {
+        const rightCoord = timeScaleApi.timeToCoordinate(toSec(hasExplicitRight ? b.x2 : b.x1));
+        xRight = rightCoord != null ? rightCoord * hpr : null;
       } else if (rightEdgeMode === 'last-bar' && rightEdgeTimeSec != null) {
-        xRight = timeScaleApi.timeToCoordinate(rightEdgeTimeSec) * hpr;
+        const rightCoord = timeScaleApi.timeToCoordinate(rightEdgeTimeSec);
+        xRight = rightCoord != null ? rightCoord * hpr : null;
       } else {
         xRight = mediaWidth; // pane edge
-      } 
+      }
       if (xLeft == null || xRight == null) continue;
 
       const y1 = priceToCoordinate(b.y1) * vpr;


### PR DESCRIPTION
## Summary
- ensure VA box drawing respects explicit x2 coordinates before falling back to extending right
- feed the latest box end time to the pane view so the optional right-edge extension is anchored to data instead of the viewport

## Testing
- npm run lint *(fails: existing lint errors across the project and cached .vite deps)*

------
https://chatgpt.com/codex/tasks/task_e_68d223fb73148331adc21332ca0a7879