### PR TITLE
Align overlay logging across backend and frontend

### DIFF
--- a/portal/backend/service/indicator_service.py
+++ b/portal/backend/service/indicator_service.py
@@ -134,7 +134,7 @@ def create_instance(type_str: str, name: Optional[str], params: Dict[str, Any]) 
     provider = AlpacaProvider()
 
     try:
-        logger.info("Instantiating %s with params=%s", type_str, params)
+        logger.info("event=indicator_create type=%s params=%s", type_str, params)
         inst = Cls.from_context(provider=provider, ctx=ctx, **params)
     except Exception as e:
         raise RuntimeError(f"Failed to instantiate indicator: {e}")
@@ -216,7 +216,7 @@ def overlays_for_instance(
     # fetch windowed OHLCV for overlay computation
     provider = AlpacaProvider()
     logger.info(
-        "Preparing overlay data | indicator=%s | symbol=%s | interval=%s | start=%s | end=%s",
+        "event=indicator_overlay_prepare indicator=%s symbol=%s interval=%s start=%s end=%s",
         inst_id,
         sym,
         interval,
@@ -236,6 +236,7 @@ def overlays_for_instance(
     else:
         raise RuntimeError("Indicator does not implement overlay serialization")
 
+    raw_payload = payload
     payload = _sanitize_json(payload)
     if not payload:
         raise LookupError("No overlays computed for given window")
@@ -247,6 +248,38 @@ def overlays_for_instance(
     )
     if not has_visuals:
         raise LookupError("No overlays computed for given window")
+
+    if isinstance(payload, dict):
+        counts = {k: len(payload.get(k) or []) for k in LAYERS if isinstance(payload.get(k), (list, tuple))}
+    else:
+        counts = {}
+
+    logger.info(
+        "event=indicator_overlay_result indicator=%s price_lines=%s markers=%s boxes=%s segments=%s polylines=%s",
+        inst_id,
+        counts.get("price_lines", 0),
+        counts.get("markers", 0),
+        counts.get("boxes", 0),
+        counts.get("segments", 0),
+        counts.get("polylines", 0),
+    )
+
+    boxes = []
+    if isinstance(raw_payload, dict):
+        boxes = raw_payload.get("boxes") or []
+    if isinstance(boxes, list):
+        for idx, box in enumerate(boxes):
+            if not isinstance(box, dict):
+                continue
+            logger.debug(
+                "event=indicator_overlay_box indicator=%s index=%d x1=%s x2=%s y1=%s y2=%s",
+                inst_id,
+                idx,
+                box.get("x1"),
+                box.get("x2"),
+                box.get("y1"),
+                box.get("y2"),
+            )
 
     return payload
 
@@ -273,7 +306,7 @@ def generate_signals_for_instance(
 
     provider = AlpacaProvider()
     logger.info(
-        "Preparing signal data | indicator=%s | symbol=%s | interval=%s | start=%s | end=%s",
+        "event=indicator_signal_prepare indicator=%s symbol=%s interval=%s start=%s end=%s",
         inst_id,
         sym,
         interval,
@@ -290,7 +323,7 @@ def generate_signals_for_instance(
     rule_config.setdefault("symbol", sym)
 
     logger.info(
-        "Running signal rules for indicator %s (%s) | symbol=%s | interval=%s | start=%s | end=%s | config=%s",
+        "event=indicator_signal_execute indicator=%s name=%s symbol=%s interval=%s start=%s end=%s config=%s",
         inst_id,
         getattr(inst, "NAME", inst.__class__.__name__),
         sym,
@@ -304,7 +337,7 @@ def generate_signals_for_instance(
     overlays = build_signal_overlays(inst, signals, df, **rule_config)
 
     logger.info(
-        "Signal execution complete for indicator %s: %d signal(s), %d overlay artefact(s)",
+        "event=indicator_signal_complete indicator=%s signals=%d overlays=%d",
         inst_id,
         len(signals),
         len(overlays),

--- a/portal/frontend/src/App.jsx
+++ b/portal/frontend/src/App.jsx
@@ -1,15 +1,16 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { ChartStateProvider } from './contexts/ChartStateContext'
 import { ChartComponent } from './components/ChartComponent/ChartComponent'
 import { TabManager } from './components/TabManager'
+import { createLogger } from './utils/logger.js'
 
 export default function App() {
   const chartId = 'main'
+  const { info } = useMemo(() => createLogger('App', { chartId }), [chartId])
 
   useEffect(() => {
-    console.log('[App] Mounted QuantTrad Lab')
-    console.log('[App] chartId:', chartId)
-  }, [])
+    info('app_mounted')
+  }, [info])
 
   return (
     <ChartStateProvider>

--- a/portal/frontend/src/adapters/candle.adapter.js
+++ b/portal/frontend/src/adapters/candle.adapter.js
@@ -1,4 +1,7 @@
+import { createLogger } from '../utils/logger.js';
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+const candleLogger = createLogger('CandleAdapter');
 
 /**
  * Adapter to fetch OHLCV candle data from backend API
@@ -11,6 +14,7 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000
  */
 export async function fetchCandleData({ symbol, timeframe, start, end }) {
   try {
+    candleLogger.debug('fetch_candles_request', { symbol, timeframe, start, end });
     const res = await fetch(`${API_BASE_URL}/api/candles`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -22,9 +26,11 @@ export async function fetchCandleData({ symbol, timeframe, start, end }) {
     }
 
     const { candles } = await res.json();
-    return Array.isArray(candles) ? candles : [];
+    const items = Array.isArray(candles) ? candles : [];
+    candleLogger.info('fetch_candles_success', { symbol, timeframe, candles: items.length });
+    return items;
   } catch (err) {
-    console.error("[CandleAdapter] fetch failed:", err);
+    candleLogger.error('fetch_candles_failed', { symbol, timeframe }, err);
     return [];
   }
 }

--- a/portal/frontend/src/adapters/indicator.adapter.js
+++ b/portal/frontend/src/adapters/indicator.adapter.js
@@ -1,4 +1,7 @@
+import { createLogger } from '../utils/logger.js';
+
 const BASE = import.meta.env.REACT_APP_API_BASE_URL || 'http://localhost:8000'
+const adapterLogger = createLogger('IndicatorAdapter');
 
 async function handleResponse(res) {
   if (res.ok) {
@@ -16,7 +19,11 @@ async function handleResponse(res) {
       payload = text || null
     }
   } catch (err) {
-    console.warn('[IndicatorAdapter] Failed to parse error response:', err)
+    adapterLogger.warn('error_response_parse_failed', {
+      status: res.status,
+      url: res.url,
+      contentType,
+    }, err)
   }
 
   const detail =
@@ -49,8 +56,11 @@ export async function fetchIndicatorType(id) {
 }
 
 export async function createIndicator({ type, name, params }) {
-  var body = JSON.stringify({ type, name, params })
-  console.log("[IndicatorAdapter] createIndicator body:", body)
+  adapterLogger.debug('create_indicator_request', {
+    type,
+    hasName: Boolean(name),
+    paramKeys: Object.keys(params || {}),
+  })
   const res = await fetch(`${BASE}/api/indicators/`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -79,7 +89,7 @@ export async function deleteIndicator(id) {
 }
 
 export async function fetchIndicatorOverlays(id, { start, end, interval, symbol }) {
-  console.log("[IndicatorAdapter] fetchIndicatorOverlays params:", { id, start, end, interval, symbol })
+  adapterLogger.debug('fetch_indicator_overlays_request', { id, start, end, interval, symbol })
   const res = await fetch(`${BASE}/api/indicators/${id}/overlays`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/portal/frontend/src/components/ChartComponent/ChartComponent.jsx
+++ b/portal/frontend/src/components/ChartComponent/ChartComponent.jsx
@@ -18,7 +18,8 @@ const LOG_NS = 'ChartComponent';
 
 export const ChartComponent = ({ chartId }) => {
   // Logger for this file.
-  const { debug, info, warn, error } = useMemo(() => createLogger(LOG_NS), []);
+  const logger = useMemo(() => createLogger(LOG_NS, { chartId }), [chartId]);
+  const { debug, info, warn, error } = logger;
 
   // Context wiring.
   const { registerChart, updateChart, bumpRefresh } = useChartState();
@@ -88,7 +89,7 @@ export const ChartComponent = ({ chartId }) => {
       seededRef.current = true;
     }
 
-    info('chart created', { chartId });
+    info('chart_created');
 
     return () => {
       try {
@@ -101,7 +102,7 @@ export const ChartComponent = ({ chartId }) => {
         chartRef.current?.remove();
         chartRef.current = null;
         seriesRef.current = null;
-        info('chart removed', { chartId });
+        info('chart_removed');
       } catch (e) {
         error('cleanup failed', e);
       }
@@ -116,7 +117,7 @@ export const ChartComponent = ({ chartId }) => {
     const ro = new ResizeObserver(([entry]) => {
       const r = entry?.contentRect; if (!r) return;
       chartRef.current.applyOptions({ width: r.width, height: r.height });
-      debug('resize', { w: r.width, h: r.height });
+      debug('chart_resize', { width: r.width, height: r.height });
     });
 
     ro.observe(el);
@@ -148,11 +149,11 @@ export const ChartComponent = ({ chartId }) => {
     try {
       setDataLoading(true);
       if (!symbol || !interval || !startISO || !endISO) {
-        warn('missing inputs', { symbol, interval, startISO, endISO });
+        warn('chart_load_missing_inputs', { symbol, interval, startISO, endISO });
         return;
       }
 
-      info('fetch', { symbol, interval, startISO, endISO });
+      info('candles_fetch_start', { symbol, interval, startISO, endISO });
       const resp = await fetchCandleData({
         symbol,
         timeframe: interval,
@@ -216,13 +217,13 @@ export const ChartComponent = ({ chartId }) => {
         chartRef.current?.timeScale().scrollToRealTime(); // fallback to latest
       }
 
-      info('data set', {
+      info('candles_fetch_success', {
         points: data.length,
         first: data[0]?.time,
         last: data.at(-1)?.time,
       });
     } catch (e) {
-      error('load failed', e);
+      error('candles_fetch_failed', e);
     } finally {
       setDataLoading(false);
     }
@@ -267,11 +268,29 @@ export const ChartComponent = ({ chartId }) => {
 
     // 3) Walk overlays and apply.
     for (const ov of overlays) {
-      const { type, payload, color } = ov || {};
+      const { type, payload, color, ind_id: indicatorId } = ov || {};
       if (!payload) continue;
+
+      const overlayLogger = logger.child({ indicatorId, indicatorType: type });
+      overlayLogger.debug('overlay_payload_received', {
+        priceLines: Array.isArray(payload.price_lines) ? payload.price_lines.length : 0,
+        markers: Array.isArray(payload.markers) ? payload.markers.length : 0,
+        boxes: Array.isArray(payload.boxes) ? payload.boxes.length : 0,
+        segments: Array.isArray(payload.segments) ? payload.segments.length : 0,
+        polylines: Array.isArray(payload.polylines) ? payload.polylines.length : 0,
+      });
 
       const paneViews = getPaneViewsFor(type);
       const norm = adaptPayload(type, payload, color);
+      overlayLogger.debug('overlay_adapted', {
+        priceLines: Array.isArray(norm.priceLines) ? norm.priceLines.length : 0,
+        markers: Array.isArray(norm.markers) ? norm.markers.length : 0,
+        touchPoints: Array.isArray(norm.touchPoints) ? norm.touchPoints.length : 0,
+        boxes: Array.isArray(norm.boxes) ? norm.boxes.length : 0,
+        segments: Array.isArray(norm.segments) ? norm.segments.length : 0,
+        polylines: Array.isArray(norm.polylines) ? norm.polylines.length : 0,
+        bubbles: Array.isArray(norm.bubbles) ? norm.bubbles.length : 0,
+      });
 
       // 3a) Price lines.
       if (Array.isArray(payload.price_lines)) {
@@ -308,16 +327,28 @@ export const ChartComponent = ({ chartId }) => {
 
       // 3d) VA Boxes.
       if (paneViews.includes('va_box') && norm.boxes?.length) {
-        boxes.push(
-          ...norm.boxes.map(b => ({
-            x1: toSec(b.x1),
-            x2: toSec(b.x2),
-            y1: Number(b.y1),
-            y2: Number(b.y2),
-            color: b.color,
-            border: b.border,
-          }))
-        );
+        const normalizedBoxes = norm.boxes.map(b => ({
+          x1: toSec(b.x1),
+          x2: toSec(b.x2),
+          y1: Number(b.y1),
+          y2: Number(b.y2),
+          color: b.color,
+          border: b.border,
+        }));
+        boxes.push(...normalizedBoxes);
+        normalizedBoxes.forEach((b, idx) => {
+          const width = Number.isFinite(b.x2) && Number.isFinite(b.x1)
+            ? Number(b.x2) - Number(b.x1)
+            : null;
+          overlayLogger.debug('va_box_applied', {
+            boxIndex: idx,
+            x1: b.x1,
+            x2: b.x2,
+            y1: b.y1,
+            y2: b.y2,
+            width,
+          });
+        });
       }
 
       if (paneViews.includes('segment') && norm.segments?.length) {
@@ -361,11 +392,11 @@ export const ChartComponent = ({ chartId }) => {
       // --- C: VWAP vs Candles coverage + coordinate check ---
       // seriesRef.current.setData(touch)
     } catch (e) {
-      error('setMarkers failed', e);
+      error('overlays_apply_failed', e);
     }
 
     // 6) Log summary for quick tracing.
-    info('overlays applied', {
+    info('overlays_applied', {
       priceLines: overlayHandlesRef.current.priceLines.length,
       markers: markers.length,
       touchPoints: touchPoints.length,
@@ -376,7 +407,7 @@ export const ChartComponent = ({ chartId }) => {
     });
 
     setDataLoading(false);
-  }, [info, error]);
+  }, [info, error, logger]);
 
   // React to overlay changes.
   useEffect(() => {

--- a/portal/frontend/src/components/IndicatorModal.v2.jsx
+++ b/portal/frontend/src/components/IndicatorModal.v2.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Dialog, DialogPanel, DialogTitle, Disclosure, Switch } from "@headlessui/react";
 import { ChevronDown, Copy, RotateCcw } from "lucide-react";
 import { fetchIndicatorTypes, fetchIndicatorType } from "../adapters/indicator.adapter";
+import { createLogger } from "../utils/logger.js";
 
 /**
  * Goals
@@ -33,6 +34,11 @@ export default function IndicatorModalV2({
   const [name, setName] = useState(initial?.name || "");
   const [params, setParams] = useState(initial?.params || {});
   const [metaErr, setMetaErr] = useState(null);
+
+  const logger = useMemo(
+    () => createLogger("IndicatorModal", { indicatorId: initial?.id ?? null }),
+    [initial?.id]
+  );
   const [typeMeta, setTypeMeta] = useState({
     required_params: [],
     default_params: {},
@@ -288,7 +294,7 @@ export default function IndicatorModalV2({
     try {
       await navigator.clipboard.writeText(JSON.stringify(params, null, 2));
     } catch (e) {
-      console.error("copy failed", e);
+      logger.error("copy_params_failed", e);
     }
   };
 

--- a/portal/frontend/src/components/IndicatorTab.jsx
+++ b/portal/frontend/src/components/IndicatorTab.jsx
@@ -15,6 +15,7 @@ import IndicatorModalV2 from './IndicatorModal.v2.jsx'
 const IndicatorModal = IndicatorModalV2; // for now, swap in new version under old name
 import { useChartState } from '../contexts/ChartStateContext'
 import IndicatorCard from './IndicatorCard.jsx';
+import { createLogger } from '../utils/logger.js';
 
 
 // Gold, Maroon, Orange, Purple, Lime, Gray
@@ -62,9 +63,19 @@ export const IndicatorSection = ({ chartId }) => {
 
   const { updateChart, getChart } = useChartState()
 
+  const logger = useMemo(() => createLogger('IndicatorSection', { chartId }), [chartId])
+  const { debug, info, warn, error: logError } = logger
+
   // Read current chart slice
   const chartState = getChart(chartId)
-  console.log('[IndicatorSection] chartId:', chartId, 'chartState:', chartState)
+
+  useEffect(() => {
+    debug('indicator_chart_state_snapshot', {
+      hasState: Boolean(chartState),
+      version: chartState?._version ?? 0,
+      overlayCount: chartState?.overlays?.length ?? 0,
+    });
+  }, [chartState, debug]);
 
   // Derive ISO start/end from dateRange
   const [startISO, endISO] = useMemo(() => {
@@ -76,12 +87,15 @@ export const IndicatorSection = ({ chartId }) => {
 
   useEffect(() => {
     if (!chartState || !chartState._version) {
-      console.warn('[IndicatorSection] No chart state version yet, skipping fetch');
+      warn('indicator_refresh_skipped_version', { reason: 'no_version' });
       setIsLoading(false);
       return;
     }
     if (!chartState.symbol || !chartState.interval) {
-      console.warn('[IndicatorSection] Missing symbol/interval, skipping fetch');
+      warn('indicator_refresh_skipped_inputs', {
+        symbol: chartState.symbol,
+        interval: chartState.interval,
+      });
       setIsLoading(false);
       return;
     }
@@ -98,7 +112,7 @@ export const IndicatorSection = ({ chartId }) => {
       } catch (e) {
         if (isMounted) {
           setError(e.message);
-          console.error('[IndicatorSection] Refresh failed:', e);
+          logError('indicator_refresh_failed', e);
         }
       } finally {
         if (isMounted) setIsLoading(false);
@@ -124,7 +138,6 @@ export const IndicatorSection = ({ chartId }) => {
   const refreshEnabledOverlays = async (list = indicators) => {
     updateChart(chartId, { overlayLoading: true }); // show loading state
 
-    console.log('[IndicatorSection - Overlays] Refresh start for chartId:', chartId);
     if (!chartState) return;
 
     // if list is empty/undefined, try one fetch to seed; otherwise use provided/current list
@@ -135,7 +148,7 @@ export const IndicatorSection = ({ chartId }) => {
         setIndicators(working);
         updateChart(chartId, { indicators: working });
       } catch (e) {
-        console.error('[IndicatorSection - Overlays] Failed to seed indicators:', e);
+        logError('indicator_seed_failed', e);
         updateChart(chartId, { overlays: [] });
         return;
       }
@@ -143,6 +156,11 @@ export const IndicatorSection = ({ chartId }) => {
 
     // patch params for enabled indicators if symbol/interval mismatch
     const enabled = working.filter(i => i?.enabled);
+    info('overlay_refresh_start', {
+      enabled: enabled.length,
+      symbol: chartState.symbol,
+      interval: chartState.interval,
+    });
     const patched = await Promise.all(enabled.map(async (ind) => {
       const p = ind?.params || {};
       const desiredSymbol = chartState.symbol;
@@ -156,7 +174,7 @@ export const IndicatorSection = ({ chartId }) => {
         const updated = await updateIndicator(ind.id, { type: ind.type, params: nextParams, name: ind.name });
         return updated || { ...ind, params: nextParams };
       } catch (e) {
-        console.warn('[IndicatorSection - Overlays] Param patch failed for', ind.id, e);
+        warn('indicator_param_patch_failed', { indicatorId: ind.id, message: e?.message }, e);
         // fall back locally so overlays still align this session
         return { ...ind, params: { ...p, symbol: desiredSymbol, interval: desiredInterval, start: startISO, end: endISO } };
       }
@@ -182,6 +200,11 @@ export const IndicatorSection = ({ chartId }) => {
       patched.map(async (ind) => {
         try {
           const payload = await fetchIndicatorOverlays(ind.id, body);
+          info('overlay_fetch_success', {
+            indicatorId: ind.id,
+            indicatorType: ind.type,
+            hasPayload: Boolean(payload),
+          });
           return payload ? { ind_id: ind.id, type: ind.type, payload } : null;
         } catch (e) {
           const msg = String(e?.message ?? e);
@@ -190,10 +213,10 @@ export const IndicatorSection = ({ chartId }) => {
             msg.includes('No candles available') ||
             msg.includes('No overlays computed')
           ) {
-            console.warn(`[IndicatorSection - Overlays] Skipping ${ind.id}: ${msg}`);
+            warn('overlay_fetch_skipped', { indicatorId: ind.id, message: msg });
             return null;
           }
-          console.error(`[IndicatorSection - Overlays] Overlay error for ${ind.id}:`, e);
+          logError('overlay_fetch_failed', { indicatorId: ind.id }, e);
           return null;
         }
       })
@@ -202,7 +225,11 @@ export const IndicatorSection = ({ chartId }) => {
     const overlaysPayload = results.filter(Boolean);
     const colored = applyIndicatorColors(overlaysPayload, indColors);
     updateChart(chartId, { overlays: colored, overlayLoading: false });
-    console.log('[IndicatorSection] Updated overlays (colored):', colored);
+    info('overlay_refresh_complete', {
+      overlays: colored.length,
+      indicatorsProcessed: patched.length,
+      enabledCount: enabled.length,
+    });
   };
 
   // Handlers for modal save/delete
@@ -247,7 +274,7 @@ export const IndicatorSection = ({ chartId }) => {
       setError(null);
     } catch (e) {
       setError(e.message);
-      console.error('[IndicatorSection] Error saving indicator:', e);
+      logError('indicator_save_failed', e);
     }
   };
 
@@ -257,7 +284,7 @@ export const IndicatorSection = ({ chartId }) => {
       setIndicators(prev => prev.filter(i => i.id !== id))
     } catch (e) {
       setError(e.message)
-      console.error('[IndicatorSection] Error deleting indicator:', e)
+      logError('indicator_delete_failed', e)
     }
   }
 

--- a/portal/frontend/src/components/TabManager.jsx
+++ b/portal/frontend/src/components/TabManager.jsx
@@ -1,18 +1,23 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { IndicatorSection } from './IndicatorTab.jsx'
+import { createLogger } from '../utils/logger.js'
 
 const tabs = ['Indicators', 'Signals', 'Strategies']
 
 export const TabManager = ({ chartId }) => {
   const [activeTab, setActiveTab] = useState(tabs[0])
 
-  // Debug: log tab changes and chartId
-  console.log("[TabManager] chartId:", chartId)
-  console.log("[TabManager] Active tab:", activeTab)
+  const logger = useMemo(() => createLogger('TabManager', { chartId }), [chartId])
+  const { info, debug } = logger
 
+  useEffect(() => {
+    debug('tab_manager_initialized', { activeTab })
+  }, [activeTab, debug])
+
+  // Debug: log tab changes and chartId
   const handleTabClick = (tab) => {
     setActiveTab(tab)
-    console.log("[TabManager] Switched to tab:", tab)
+    info('tab_switched', { tab })
   }
 
   return (

--- a/portal/frontend/src/components/indicatorSignals.js
+++ b/portal/frontend/src/components/indicatorSignals.js
@@ -1,3 +1,7 @@
+import { createLogger } from '../utils/logger.js';
+
+const signalsLogger = createLogger('IndicatorSignals');
+
 export const hexToRgba = (hex, a = 0.18) => {
   if (!hex || !hex.startsWith('#')) return `rgba(156,163,175,${a})`;
   const v = hex.slice(1);
@@ -66,19 +70,32 @@ export async function runSignalGeneration({
   colorizer = applyIndicatorColors,
 }) {
   if (!indicator) {
+    signalsLogger.warn('signal_generation_skipped_indicator_missing', { chartId });
     setError?.('Cannot generate signals: indicator not found.');
     return false;
   }
 
   if (!chartState || !chartState.symbol || !chartState.interval) {
+    signalsLogger.warn('signal_generation_skipped_chart_inputs', {
+      chartId,
+      hasChartState: Boolean(chartState),
+    });
     setError?.('Cannot generate signals: missing chart symbol or interval.');
     return false;
   }
 
   if (!startISO || !endISO) {
+    signalsLogger.warn('signal_generation_skipped_window', { chartId, startISO, endISO });
     setError?.('Cannot generate signals: chart window is not ready.');
     return false;
   }
+
+  const scopedLogger = signalsLogger.child({ chartId, indicatorId: indicator.id });
+  scopedLogger.info('signal_generation_start', {
+    start: startISO,
+    end: endISO,
+    interval: chartState.interval,
+  });
 
   updateChart(chartId, { signalsLoading: true, signalsLoadingFor: indicator.id });
 
@@ -91,6 +108,8 @@ export async function runSignalGeneration({
     if (confirmationBars != null) {
       config.pivot_breakout_confirmation_bars = confirmationBars;
     }
+
+    scopedLogger.debug('signal_generation_request', { config });
 
     const response = await signalsAdapter(indicator.id, {
       start: startISO,
@@ -121,11 +140,16 @@ export async function runSignalGeneration({
       signalResults: { ...prevSignals, [indicator.id]: rawSignals },
     });
 
+    scopedLogger.info('signal_generation_complete', {
+      signals: rawSignals.length,
+      overlays: signalOverlays.length,
+    });
+
     setError?.(null);
     return true;
   } catch (err) {
     const msg = err?.message || 'Failed to generate signals.';
-    console.error(`[IndicatorSection] generateSignals failed for ${indicator?.id}:`, err);
+    scopedLogger.error('signal_generation_failed', { message: msg }, err);
     setError?.(msg);
     return false;
   } finally {

--- a/portal/frontend/src/contexts/ChartStateContext.jsx
+++ b/portal/frontend/src/contexts/ChartStateContext.jsx
@@ -43,17 +43,17 @@ export function ChartStateProvider({ children }) {
 
   // actions are stable; no effects that set state here
   const registerChart = useCallback((id, handles) => {
-    info('register', { id });
+    info('chart_register', { chartId: id });
     dispatch({ type: 'REGISTER', id, handles });
   }, [info]);
 
   const updateChart = useCallback((id, patch) => {
-    debug('update', { id, keys: Object.keys(patch) });
+    debug('chart_update', { chartId: id, keys: Object.keys(patch) });
     dispatch({ type: 'UPDATE', id, patch });
   }, [debug]);
 
   const bumpRefresh = useCallback((id) => {
-    debug('bump', { id });
+    debug('chart_bump', { chartId: id });
     dispatch({ type: 'BUMP', id });
   }, [debug]);
 

--- a/portal/frontend/src/utils/logger.js
+++ b/portal/frontend/src/utils/logger.js
@@ -1,27 +1,104 @@
-// Minimal namespaced logger with levels.
 const LEVELS = { debug: 10, info: 20, warn: 30, error: 40, silent: 50 };
 
 let globalLevel = (import.meta?.env?.MODE === 'production') ? 'warn' : 'debug';
-try { globalLevel = localStorage.getItem('LOG_LEVEL') || globalLevel; } catch {}
+try {
+  const stored = typeof localStorage !== 'undefined' ? localStorage.getItem('LOG_LEVEL') : null;
+  if (stored && LEVELS[stored]) globalLevel = stored;
+} catch {
+  /* ignore storage access issues */
+}
 
-let sink = null; // Optional external sink.
+let sink = null; // Optional external sink for piping logs elsewhere.
 
-export function setLogLevel(level) { if (LEVELS[level]) globalLevel = level; }
-export function setLogSink(fn) { sink = (typeof fn === 'function') ? fn : null; }
+export function setLogLevel(level) {
+  if (LEVELS[level]) globalLevel = level;
+}
 
-export function createLogger(namespace = 'app') {
-  const ts = () => new Date().toISOString();
-  const allowed = (lvl) => LEVELS[lvl] >= LEVELS[globalLevel];
-  const make = (lvl, method = 'log') => (...args) => {
-    if (!allowed(lvl)) return;
-    const prefix = `[${ts()}] [${namespace}]`;
-    (console[method] || console.log)(prefix, ...args);
-    if (sink) { try { sink(lvl, namespace, ...args); } catch {} }
+export function setLogSink(fn) {
+  sink = (typeof fn === 'function') ? fn : null;
+}
+
+const formatValue = (value) => {
+  if (value === undefined) return 'undefined';
+  if (value === null) return 'null';
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (typeof value === 'string') {
+    return /\s/.test(value) ? JSON.stringify(value) : value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const formatContext = (context) => {
+  if (!context) return '';
+  const entries = Object.entries(context)
+    .filter(([, v]) => v !== undefined)
+    .map(([k, v]) => `${k}=${formatValue(v)}`);
+  return entries.length ? ` ${entries.join(' ')}` : '';
+};
+
+const normalizeArgs = (baseCtx, args) => {
+  const [eventOrMessage, maybeCtx, ...rest] = args;
+  const extras = [];
+  let event = typeof eventOrMessage === 'string' ? eventOrMessage : 'log';
+  let ctx = { ...baseCtx };
+
+  const mergeCtx = (candidate) => {
+    if (candidate && typeof candidate === 'object' && !Array.isArray(candidate) && !(candidate instanceof Error)) {
+      ctx = { ...ctx, ...candidate };
+      return true;
+    }
+    return false;
   };
+
+  if (!mergeCtx(maybeCtx) && maybeCtx !== undefined) {
+    extras.push(maybeCtx);
+  }
+
+  for (const item of rest) {
+    if (!mergeCtx(item)) extras.push(item);
+  }
+
+  return { event, ctx, extras };
+};
+
+const makeFormatter = (namespace) => (level) => (event, ctx) => {
+  const ts = new Date().toISOString();
+  const contextStr = formatContext(ctx);
+  const eventStr = typeof event === 'string' ? `event=${event}` : `event=${formatValue(event)}`;
+  return `[${ts}] ${level.toUpperCase()} ${namespace} ${eventStr}${contextStr}`;
+};
+
+export function createLogger(namespace = 'app', baseContext = {}) {
+  const allowed = (lvl) => LEVELS[lvl] >= LEVELS[globalLevel];
+  const formatter = makeFormatter(namespace);
+
+  const logWith = (lvl, method = 'log') => (...args) => {
+    if (!allowed(lvl)) return;
+    const { event, ctx, extras } = normalizeArgs(baseContext, args);
+    const line = formatter(lvl)(event, ctx);
+    const sinkPayload = { level: lvl, namespace, event, context: ctx, extras };
+    try {
+      (console[method] || console.log)(line, ...extras);
+    } catch {
+      // ignore console issues
+    }
+    if (sink) {
+      try { sink(sinkPayload); } catch { /* ignore sink errors */ }
+    }
+  };
+
   return {
-    debug: make('debug', 'log'),
-    info:  make('info',  'info'),
-    warn:  make('warn',  'warn'),
-    error: make('error', 'error'),
+    debug: logWith('debug', 'debug'),
+    info: logWith('info', 'info'),
+    warn: logWith('warn', 'warn'),
+    error: logWith('error', 'error'),
+    child(extraCtx = {}) {
+      return createLogger(namespace, { ...baseContext, ...extraCtx });
+    },
   };
 }

--- a/src/indicators/market_profile.py
+++ b/src/indicators/market_profile.py
@@ -210,7 +210,11 @@ class MarketProfileIndicator(BaseIndicator):
         legend_entries = set()
         full_idx = plot_df.index
 
-        logger.info("Generating overlays for %d profiles (use_merged=%s)", len(profiles), use_merged)
+        logger.info(
+            "event=market_profile_overlay_start profiles=%d use_merged=%s",
+            len(profiles),
+            use_merged,
+        )
         for idx, prof in enumerate(profiles):
             # Robustly get the start timestamp
             try:
@@ -245,7 +249,12 @@ class MarketProfileIndicator(BaseIndicator):
                 "alpha": 0.2
             })
             legend_entries.add(("Value Area", "gray"))
-            logger.debug("Overlay rect: start=%s, VAL=%.2f, VAH=%.2f", start_ts, val, vah)
+            logger.debug(
+                "event=market_profile_rect start=%s val=%.4f vah=%.4f",
+                start_ts,
+                val,
+                vah,
+            )
 
             # 2) optional POC line as an addplot
             if poc is not None:
@@ -255,9 +264,12 @@ class MarketProfileIndicator(BaseIndicator):
                 ap = make_addplot(poc_series, color="orange", width=1.0, linestyle="--")
                 overlays.append({"kind": "addplot", "plot": ap})
                 legend_entries.add(("POC", "orange"))
-                logger.debug("Overlay POC: start=%s, POC=%.2f", start_ts, poc)
-
-        logger.info("Generated %d overlays", len(overlays))
+                logger.debug(
+                    "event=market_profile_poc start=%s poc=%.4f",
+                    start_ts,
+                    poc,
+                )
+        logger.info("event=market_profile_overlay_complete overlays=%d", len(overlays))
         return overlays, legend_entries
 
     @staticmethod
@@ -324,6 +336,13 @@ class MarketProfileIndicator(BaseIndicator):
 
         out_lines, out_markers, out_boxes = [], [], []
 
+        logger.info(
+            "event=market_profile_lightweight_start profiles=%d chart_start=%s chart_end=%s",
+            len(profiles),
+            chart_start,
+            chart_end,
+        )
+
         for prof in profiles:
             # accept either merged keys ('start') or daily keys ('start_date')
             start_ts = pd.to_datetime(prof.get("start") or prof.get("start_date"), utc=True)
@@ -358,6 +377,16 @@ class MarketProfileIndicator(BaseIndicator):
                 "y2": float(vah),             # VAH
                 "color": "rgba(156,163,175,0.18)",   # neutral grey w/ alpha; UI can recolor later
             })
+
+            logger.debug(
+                "event=market_profile_lightweight_box start=%s end=%s x1=%d x2=%d y1=%.4f y2=%.4f",
+                start_ts,
+                end_ts,
+                _to_unix_s(start_ts),
+                _to_unix_s(end_ts),
+                float(val),
+                float(vah),
+            )
 
             # ----- price lines (Lightweight "price line" settings) -----
             # # VAL (solid)
@@ -399,6 +428,13 @@ class MarketProfileIndicator(BaseIndicator):
             if include_touches:
                 out_markers.extend(_find_touch_markers(plot_df, float(val), start_ts, "VAL", fmt_time))
                 out_markers.extend(_find_touch_markers(plot_df, float(vah), start_ts, "VAH", fmt_time))
+
+        logger.info(
+            "event=market_profile_lightweight_summary price_lines=%d markers=%d boxes=%d",
+            len(out_lines),
+            len(out_markers),
+            len(out_boxes),
+        )
 
         return {
             "price_lines": out_lines,


### PR DESCRIPTION
## Summary
- add structured indicator logging for overlay generation, signal execution, and market profile value-area boxes to aid tracing in Loki
- replace the frontend logger with a contextual key/value emitter and instrument chart, indicator, and adapter flows with matching IDs
- expand chart overlay handling logs to expose normalized VA box ranges for debugging truncation issues

## Testing
- npm run lint *(fails: vendored deps under .vite raise lint errors)*
- pytest tests/test_indicators/test_market_profile_indicator.py *(fails: pandas missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d30310233c8331b9d5cad26927eeb4