### PR TITLE
Revamp indicator modal layout

### DIFF
--- a/portal/frontend/src/components/IndicatorModal.v2.jsx
+++ b/portal/frontend/src/components/IndicatorModal.v2.jsx
@@ -1,7 +1,14 @@
 // src/components/IndicatorModal.v2.jsx
 import React, { useEffect, useMemo, useState } from "react";
-import { Dialog, DialogPanel, DialogTitle, Disclosure, Switch } from "@headlessui/react";
-import { ChevronDown, Copy, RotateCcw } from "lucide-react";
+import { Dialog, DialogPanel, DialogTitle, Switch } from "@headlessui/react";
+import {
+  Braces,
+  ChevronDown,
+  Copy,
+  RotateCcw,
+  Search,
+  SlidersHorizontal,
+} from "lucide-react";
 import { fetchIndicatorTypes, fetchIndicatorType } from "../adapters/indicator.adapter";
 import { createLogger } from "../utils/logger.js";
 
@@ -150,8 +157,14 @@ export default function IndicatorModalV2({
 
   /** UI state **/
   const [filter, setFilter] = useState("");
-  const [showRaw, setShowRaw] = useState(false);
-  const [expandAll, setExpandAll] = useState(false);
+  const [rawOpen, setRawOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setAdvancedOpen(false);
+    setRawOpen(false);
+  }, [isOpen, typeId]);
 
   // Heuristics for grouping: Essential vs Advanced
   const basicHints = useMemo(() => new Set([
@@ -203,22 +216,30 @@ export default function IndicatorModalV2({
     const ftype = ftypeOf(key);
     const val = params[key];
     const enumVals = enumsFor(key);
+    const boolValue = !!val;
 
     // searchable filter
     if (filter && !key.toLowerCase().includes(filter.toLowerCase())) return null;
 
     return (
-      <div key={key} className="space-y-1">
-        <div className="flex items-center justify-between">
-          <label className="block text-sm font-medium text-neutral-200">
-            {key}
-            {typeMeta.required_params?.includes(key) && (
-              <span className="text-red-500 ml-1">*</span>
+      <div
+        key={key}
+        className="space-y-2 rounded-lg border border-neutral-700/70 bg-neutral-800/50 p-3"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <label className="block text-sm font-semibold text-neutral-100">
+              {key}
+              {typeMeta.required_params?.includes(key) && (
+                <span className="text-red-500 ml-1">*</span>
+              )}
+            </label>
+            {descriptionFor(key) && (
+              <p className="text-xs text-neutral-400 leading-5">
+                {descriptionFor(key)}
+              </p>
             )}
-          </label>
-          {descriptionFor(key) && (
-            <span className="text-xs text-neutral-400 ml-2">{descriptionFor(key)}</span>
-          )}
+          </div>
         </div>
 
         {intListKeys.has(key) ? (
@@ -226,7 +247,7 @@ export default function IndicatorModalV2({
             type="text"
             inputMode="numeric"
             pattern="^[0-9\\s,;]*$"
-            className="w-full p-2 rounded bg-neutral-700"
+            className="w-full rounded-lg border border-neutral-700/70 bg-neutral-900/60 px-3 py-2 text-sm focus:border-indigo-500/70 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
             value={listToString(val)}
             placeholder="e.g., 5, 10, 20"
             onChange={(e) => setParams((p) => ({ ...p, [key]: e.target.value }))}
@@ -234,7 +255,7 @@ export default function IndicatorModalV2({
           />
         ) : enumVals?.length ? (
           <select
-            className="w-full p-2 rounded bg-neutral-700"
+            className="w-full rounded-lg border border-neutral-700/70 bg-neutral-900/60 px-3 py-2 text-sm focus:border-indigo-500/70 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
             value={String(val ?? "")}
             onChange={(e) => setParams((p) => ({ ...p, [key]: e.target.value }))}
           >
@@ -247,19 +268,21 @@ export default function IndicatorModalV2({
         ) : ftype === "bool" ? (
           <div className="flex items-center gap-3">
             <Switch
-              checked={Boolean(val)}
+              checked={boolValue}
               onChange={(checked) => setParams((p) => ({ ...p, [key]: checked }))}
-              className={`${Boolean(val) ? "bg-indigo-600" : "bg-neutral-600"} relative inline-flex h-6 w-11 items-center rounded-full transition-colors`}
+              className={`${boolValue ? "bg-indigo-600" : "bg-neutral-600"} relative inline-flex h-6 w-11 items-center rounded-full transition-colors`}
             >
-              <span className={`${Boolean(val) ? "translate-x-6" : "translate-x-1"} inline-block h-4 w-4 transform rounded-full bg-white transition-transform`} />
+              <span className={`${boolValue ? "translate-x-6" : "translate-x-1"} inline-block h-4 w-4 transform rounded-full bg-white transition-transform`} />
             </Switch>
-            <span className="text-sm text-neutral-300">{String(val)}</span>
+            <span className="text-sm text-neutral-300">
+              {boolValue ? "Enabled" : "Disabled"}
+            </span>
           </div>
         ) : ["int", "float", "number"].includes(ftype) ? (
           <input
             type="number"
             step={ftype === "int" ? 1 : "any"}
-            className="w-full p-2 rounded bg-neutral-700"
+            className="w-full rounded-lg border border-neutral-700/70 bg-neutral-900/60 px-3 py-2 text-sm focus:border-indigo-500/70 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
             value={Number.isFinite(val) ? val : ""}
             onChange={(e) =>
               setParams((p) => ({ ...p, [key]: e.target.valueAsNumber }))
@@ -268,7 +291,7 @@ export default function IndicatorModalV2({
         ) : (
           <input
             type="text"
-            className="w-full p-2 rounded bg-neutral-700"
+            className="w-full rounded-lg border border-neutral-700/70 bg-neutral-900/60 px-3 py-2 text-sm focus:border-indigo-500/70 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
             value={val ?? ""}
             onChange={(e) => setParams((p) => ({ ...p, [key]: e.target.value }))}
           />
@@ -303,9 +326,12 @@ export default function IndicatorModalV2({
     const fields = keys.map(renderField).filter(Boolean);
     if (!fields.length) return null;
     return (
-      <div className="space-y-3">
-        <h4 className="text-sm font-semibold text-neutral-300">{title}</h4>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">{fields}</div>
+      <div className="rounded-xl border border-neutral-700/80 bg-neutral-800/40 p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h4 className="text-sm font-semibold text-neutral-200">{title}</h4>
+          <span className="text-xs text-neutral-400">{fields.length} fields</span>
+        </div>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">{fields}</div>
       </div>
     );
   };
@@ -314,148 +340,224 @@ export default function IndicatorModalV2({
     <Dialog open={isOpen} onClose={onClose} className="relative z-50">
       <div className="fixed inset-0 bg-black/40" aria-hidden="true" />
       <div className="fixed inset-0 flex items-center justify-center p-4">
-        <DialogPanel className="w-full max-w-3xl bg-neutral-800 text-neutral-200 rounded-xl p-6 space-y-4 shadow-2xl border border-neutral-700">
-          <DialogTitle className="text-lg font-semibold">
-            {initial?.id ? "Edit Indicator" : "Create Indicator"}
-          </DialogTitle>
+        <DialogPanel className="w-full max-w-5xl overflow-hidden rounded-2xl border border-neutral-700/80 bg-neutral-950/90 text-neutral-100 shadow-2xl backdrop-blur">
+          <div className="border-b border-neutral-800 bg-neutral-900/80 px-6 py-4">
+            <DialogTitle className="text-lg font-semibold">
+              {initial?.id ? "Edit Indicator" : "Create Indicator"}
+            </DialogTitle>
+            <p className="mt-1 text-sm text-neutral-400">
+              Configure signal logic quickly with grouped essentials and one-click tools.
+            </p>
+          </div>
 
-          {(metaErr || error) && (
-            <div className="text-red-400 text-sm">{metaErr || error}</div>
-          )}
+          <div className="flex flex-col gap-6 px-6 py-6 lg:flex-row">
+            <div className="flex-1 space-y-6">
+              {(metaErr || error) && (
+                <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-2 text-sm text-red-200">
+                  {metaErr || error}
+                </div>
+              )}
 
-          {/* Top: Name + Type */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-            <div className="md:col-span-1">
-              <label className="block text-sm mb-1">Name</label>
-              <input
-                type="text"
-                className="w-full p-2 rounded bg-neutral-700"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-              />
-            </div>
-            <div className="md:col-span-1">
-              <label className="block text-sm mb-1">Indicator Type</label>
-              {initial?.id ? (
-                <div className="px-3 py-2 bg-neutral-700 rounded">{typeId}</div>
-              ) : (
-                <select
-                  className="w-full p-2 rounded bg-neutral-700"
-                  value={typeId}
-                  onChange={(e) => setTypeId(e.target.value)}
-                >
-                  <option value="">— select type —</option>
-                  {types.map((t) => (
-                    <option key={t} value={t}>
-                      {t}
-                    </option>
-                  ))}
-                </select>
+              {/* Top: Name + Type */}
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-neutral-200">Name</label>
+                  <input
+                    type="text"
+                    className="w-full rounded-lg border border-neutral-700/70 bg-neutral-900/60 px-3 py-2 text-sm focus:border-indigo-500/70 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium text-neutral-200">Indicator Type</label>
+                  {initial?.id ? (
+                    <div className="rounded-lg border border-neutral-700/70 bg-neutral-900/60 px-3 py-2 text-sm">
+                      {typeId}
+                    </div>
+                  ) : (
+                    <select
+                      className="w-full rounded-lg border border-neutral-700/70 bg-neutral-900/60 px-3 py-2 text-sm focus:border-indigo-500/70 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                      value={typeId}
+                      onChange={(e) => setTypeId(e.target.value)}
+                    >
+                      <option value="">— select type —</option>
+                      {types.map((t) => (
+                        <option key={t} value={t}>
+                          {t}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+
+                {/* Quick search for params */}
+                {typeId && (
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium text-neutral-200">
+                      Search params
+                    </label>
+                    <div className="relative">
+                      <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-neutral-500" />
+                      <input
+                        type="text"
+                        className="w-full rounded-lg border border-neutral-700/70 bg-neutral-900/60 pl-9 pr-3 py-2 text-sm focus:border-indigo-500/70 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        placeholder="Filter by name (press / to focus)"
+                        value={filter}
+                        onChange={(e) => setFilter(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "/") {
+                            e.preventDefault();
+                            e.currentTarget.focus();
+                          }
+                        }}
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* PARAMS */}
+              {typeId && (
+                <div className="space-y-4">
+                  <Section title="Essential parameters" keys={basicKeys} />
+
+                  {advancedKeys.length > 0 && (
+                    <div className="rounded-xl border border-neutral-700/80 bg-neutral-800/40 p-4">
+                      <button
+                        type="button"
+                        onClick={() => setAdvancedOpen((prev) => !prev)}
+                        className="flex w-full items-center justify-between text-left text-sm font-semibold text-neutral-200"
+                      >
+                        <span className="inline-flex items-center gap-2">
+                          <SlidersHorizontal className="h-4 w-4" />
+                          Advanced parameters
+                        </span>
+                        <span className="flex items-center gap-2 text-xs font-normal text-neutral-400">
+                          {advancedKeys.length} fields
+                          <ChevronDown
+                            className={`h-4 w-4 transition-transform ${advancedOpen ? "rotate-180" : ""}`}
+                          />
+                        </span>
+                      </button>
+                      {advancedOpen ? (
+                        <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+                          {advancedKeys.map(renderField).filter(Boolean)}
+                        </div>
+                      ) : (
+                        <p className="mt-3 text-xs text-neutral-400">
+                          Keep noise out of your workflow until you need to fine tune.
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
               )}
             </div>
 
-            {/* Quick search for params */}
             {typeId && (
-              <div className="md:col-span-1">
-                <label className="block text-sm mb-1">Search params</label>
-                <input
-                  type="text"
-                  className="w-full p-2 rounded bg-neutral-700"
-                  placeholder="Filter by name ( / to focus )"
-                  value={filter}
-                  onChange={(e) => setFilter(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "/") {
-                      e.preventDefault();
-                      e.currentTarget.focus();
-                    }
-                  }}
-                />
-              </div>
+              <aside className="lg:w-72 space-y-4">
+                <div className="rounded-xl border border-neutral-700/80 bg-neutral-900/40 p-4 space-y-4">
+                  <div>
+                    <h4 className="text-sm font-semibold text-neutral-200">
+                      Workflow shortcuts
+                    </h4>
+                    <p className="text-xs text-neutral-400">
+                      Fast access to the tools you reach for every session.
+                    </p>
+                  </div>
+
+                  {advancedKeys.length > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => setAdvancedOpen((prev) => !prev)}
+                      className="flex w-full items-center justify-between rounded-lg border border-neutral-700/70 bg-neutral-950/40 px-3 py-2 text-left text-sm text-neutral-200 transition hover:border-indigo-500/60 hover:text-neutral-100"
+                    >
+                      <span className="inline-flex items-center gap-2">
+                        <SlidersHorizontal className="h-4 w-4" />
+                        {advancedOpen ? "Hide" : "Show"} advanced
+                      </span>
+                      <span className="text-xs text-neutral-400">{advancedKeys.length}</span>
+                    </button>
+                  )}
+
+                  <button
+                    type="button"
+                    onClick={copyParams}
+                    className="flex w-full items-center gap-2 rounded-lg border border-neutral-700/70 bg-neutral-950/40 px-3 py-2 text-sm text-neutral-200 transition hover:border-indigo-500/60 hover:text-neutral-100"
+                  >
+                    <Copy className="h-4 w-4" /> Copy raw params
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={resetToDefaults}
+                    className="flex w-full items-center gap-2 rounded-lg border border-neutral-700/70 bg-neutral-950/40 px-3 py-2 text-sm text-neutral-200 transition hover:border-indigo-500/60 hover:text-neutral-100"
+                  >
+                    <RotateCcw className="h-4 w-4" /> Reset to defaults
+                  </button>
+                </div>
+
+                <div className="rounded-xl border border-neutral-700/80 bg-neutral-900/40 p-4">
+                  <button
+                    type="button"
+                    onClick={() => setRawOpen((prev) => !prev)}
+                    className="flex w-full items-center justify-between text-left text-sm font-semibold text-neutral-200"
+                  >
+                    <span className="inline-flex items-center gap-2">
+                      <Braces className="h-4 w-4" />
+                      Raw params JSON
+                    </span>
+                    <ChevronDown
+                      className={`h-4 w-4 transition-transform ${rawOpen ? "rotate-180" : ""}`}
+                    />
+                  </button>
+                  {rawOpen && (
+                    <pre className="mt-3 max-h-64 overflow-auto rounded-lg border border-neutral-800 bg-neutral-950/80 p-3 text-xs leading-5 text-neutral-200">
+                      {JSON.stringify(params, null, 2)}
+                    </pre>
+                  )}
+                </div>
+
+                <div className="rounded-xl border border-neutral-700/80 bg-neutral-900/40 p-4 text-xs text-neutral-400">
+                  <p className="text-sm font-semibold text-neutral-200">Keyboard</p>
+                  <div className="mt-3 space-y-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <span>Focus parameter search</span>
+                      <kbd className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-[10px] uppercase text-neutral-300">
+                        /
+                      </kbd>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span>Submit indicator</span>
+                      <kbd className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-[10px] uppercase text-neutral-300">
+                        Enter
+                      </kbd>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span>Close panel</span>
+                      <kbd className="rounded border border-neutral-700 bg-neutral-950 px-2 py-1 text-[10px] uppercase text-neutral-300">
+                        Esc
+                      </kbd>
+                    </div>
+                  </div>
+                </div>
+              </aside>
             )}
           </div>
 
-          {/* PARAMS */}
-          {typeId && (
-            <div className="space-y-4">
-              <Section title="Essential" keys={basicKeys} />
-
-              {/* Advanced is collapsible with count */}
-              {advancedKeys.length > 0 && (
-                <Disclosure defaultOpen={expandAll}>
-                  {({ open }) => (
-                    <div className="border-t border-neutral-700 pt-3">
-                      <Disclosure.Button className="w-full flex items-center justify-between text-left">
-                        <span className="text-sm font-semibold text-neutral-300">
-                          Advanced ({advancedKeys.length})
-                        </span>
-                        <ChevronDown
-                          className={`h-4 w-4 transition-transform ${open ? "rotate-180" : ""}`}
-                        />
-                      </Disclosure.Button>
-                      <Disclosure.Panel className="mt-3">
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                          {advancedKeys.map(renderField).filter(Boolean)}
-                        </div>
-                      </Disclosure.Panel>
-                    </div>
-                  )}
-                </Disclosure>
-              )}
-
-              {/* Raw params viewer */}
-              <Disclosure>
-                {({ open }) => (
-                  <div className="border-t border-neutral-700 pt-3">
-                    <div className="flex items-center justify-between">
-                      <Disclosure.Button className="text-sm font-semibold text-neutral-300 flex items-center gap-2">
-                        <ChevronDown
-                          className={`h-4 w-4 transition-transform ${open ? "rotate-180" : ""}`}
-                        />
-                        Raw params JSON
-                      </Disclosure.Button>
-                      <div className="flex items-center gap-2">
-                        <button
-                          onClick={copyParams}
-                          type="button"
-                          className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-neutral-600 hover:bg-neutral-700"
-                          title="Copy JSON to clipboard"
-                        >
-                          <Copy className="h-3 w-3" /> Copy
-                        </button>
-                        <button
-                          onClick={resetToDefaults}
-                          type="button"
-                          className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-neutral-600 hover:bg-neutral-700"
-                          title="Reset to defaults"
-                        >
-                          <RotateCcw className="h-3 w-3" /> Reset
-                        </button>
-                      </div>
-                    </div>
-                    <Disclosure.Panel>
-                      <pre className="mt-2 max-h-56 overflow-auto bg-neutral-900 rounded p-3 text-xs leading-5">
-                        {JSON.stringify(params, null, 2)}
-                      </pre>
-                    </Disclosure.Panel>
-                  </div>
-                )}
-              </Disclosure>
-            </div>
-          )}
-
           {/* ACTIONS */}
-          <div className="sticky bottom-0 pt-4">
-            <div className="flex justify-end gap-3 border-t border-neutral-700 pt-4">
+          <div className="border-t border-neutral-800 bg-neutral-900/80 px-6 py-4">
+            <div className="flex justify-end gap-3">
               <button
                 onClick={onClose}
-                className="px-4 py-2 rounded border border-gray-600 cursor-pointer hover:bg-neutral-700"
+                className="rounded-lg border border-neutral-700/70 px-4 py-2 text-sm text-neutral-200 transition hover:border-neutral-500 hover:text-white"
               >
                 Cancel
               </button>
               <button
                 onClick={handleSubmit}
-                className="px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-700 text-white cursor-pointer disabled:opacity-50"
+                className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-500 disabled:opacity-50"
               >
                 {initial?.id ? "Update" : "Create"}
               </button>


### PR DESCRIPTION
## Summary
- restyle the indicator modal with a wider panel, grouped field cards, and modernized form controls
- add a quick-action sidebar with shortcuts for toggling advanced fields, copying params, and resetting defaults
- provide a collapsible raw JSON viewer and keyboard hints to streamline repeated edits

## Testing
- npm run lint *(fails: existing lint violations across frontend codebase and generated .vite assets)*

------
https://chatgpt.com/codex/tasks/task_e_68d3147276d4833198da285ec96fb0ae