### PR TITLE
Adopt dark QuantLab shell with refined indicator tools

### DIFF
--- a/portal/frontend/src/App.jsx
+++ b/portal/frontend/src/App.jsx
@@ -3,10 +3,46 @@ import { ChartStateProvider } from './contexts/ChartStateContext'
 import { ChartComponent } from './components/ChartComponent/ChartComponent'
 import { TabManager } from './components/TabManager'
 import { createLogger } from './utils/logger.js'
+import { useFeedStatus } from './hooks/useFeedStatus.js'
+
+const STATUS_THEME = {
+  checking: {
+    base: 'border-neutral-700/70 bg-neutral-900/70 text-neutral-400',
+    dot: 'bg-neutral-500',
+  },
+  online: {
+    base: 'border-emerald-500/40 bg-emerald-500/15 text-emerald-300',
+    dot: 'bg-emerald-400',
+  },
+  degraded: {
+    base: 'border-amber-500/40 bg-amber-500/10 text-amber-300',
+    dot: 'bg-amber-400',
+  },
+  offline: {
+    base: 'border-rose-500/40 bg-rose-500/10 text-rose-300',
+    dot: 'bg-rose-400',
+  },
+}
+
+const DEFAULT_THEME = STATUS_THEME.checking
+
+const StatusBadge = ({ label, status, detail }) => {
+  const theme = STATUS_THEME[status] ?? DEFAULT_THEME
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition ${theme.base}`}
+    >
+      <span className={`h-1.5 w-1.5 rounded-full ${theme.dot}`} aria-hidden />
+      <span>{label}</span>
+      {detail ? <span className="text-[11px] font-normal text-neutral-500">{detail}</span> : null}
+    </span>
+  )
+}
 
 export default function App() {
   const chartId = 'main'
   const { info } = useMemo(() => createLogger('App', { chartId }), [chartId])
+  const { statuses } = useFeedStatus({ refreshMs: 60000 })
 
   useEffect(() => {
     info('app_mounted')
@@ -14,16 +50,44 @@ export default function App() {
 
   return (
     <ChartStateProvider>
-      <div className="bg-neutral-900 text-white min-h-screen p-5">
-        <h1 className="text-3xl font-bold text-center mt-10">QuantTrad Lab</h1>
+      <div className="min-h-screen bg-neutral-950 text-neutral-100">
+        <header className="border-b border-neutral-800/70 bg-neutral-950/80 backdrop-blur">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-8">
+            <div className="flex flex-wrap items-center justify-between gap-6">
+              <div className="flex items-center gap-4">
+                <span className="flex h-11 w-11 items-center justify-center rounded-2xl border border-neutral-700/80 bg-neutral-900 text-sm font-semibold uppercase tracking-[0.35em] text-neutral-200">
+                  QT
+                </span>
+                <div className="flex flex-col">
+                  <span className="text-xs font-medium uppercase tracking-[0.35em] text-neutral-500">QuantTrad Portal</span>
+                  <h1 className="text-3xl font-semibold text-neutral-100 sm:text-4xl">QuantLab</h1>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => window.dispatchEvent(new CustomEvent('qt-open-symbol-palette'))}
+                className="inline-flex items-center gap-2 rounded-full border border-neutral-700/70 bg-neutral-900 px-4 py-2 text-sm font-medium text-neutral-300 shadow-sm transition hover:border-neutral-500 hover:text-neutral-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500"
+              >
+                <span className="text-neutral-400">Search symbols</span>
+                <kbd className="rounded border border-neutral-700/60 bg-neutral-900 px-1.5 py-0.5 text-[11px] font-semibold text-neutral-400">/</kbd>
+              </button>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+              {statuses.map((s) => (
+                <StatusBadge key={s.key} label={s.label} status={s.status} detail={s.detail} />
+              ))}
+            </div>
+          </div>
+        </header>
 
-        <div className="max-w-7xl mx-auto mt-10 p-5 bg-neutral-800 rounded-lg shadow-lg">
-          <ChartComponent chartId={chartId} />
-        </div>
-
-        <div className="max-w-7xl mx-auto mt-10 p-5 bg-neutral-800 rounded-lg shadow-lg">
-          <TabManager chartId={chartId} />
-        </div>
+        <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-10 lg:grid lg:grid-cols-[2fr,1fr]">
+          <section className="flex flex-col">
+            <ChartComponent chartId={chartId} />
+          </section>
+          <aside className="flex flex-col">
+            <TabManager chartId={chartId} />
+          </aside>
+        </main>
       </div>
     </ChartStateProvider>
   )

--- a/portal/frontend/src/components/ChartComponent/ChartComponent.jsx
+++ b/portal/frontend/src/components/ChartComponent/ChartComponent.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { createChart, CandlestickSeries, createSeriesMarkers} from 'lightweight-charts';
-import { TimeframeSelect, SymbolInput } from './TimeframeSelectComponent';
+import { TimeframeSelect } from './TimeframeSelectComponent';
 import { DateRangePickerComponent } from './DateTimePickerComponent';
 import { options, seriesOptions } from './ChartOptions';
 import { fetchCandleData } from '../../adapters/candle.adapter';
@@ -165,7 +165,7 @@ export const ChartComponent = ({ chartId }) => {
     return () => ro.disconnect();
   }, [debug]);
 
-  useEffect(() => {
+  useEffect(() => { 
     const onKey = (e) => {
       if (e.key === '/' && !e.metaKey && !e.ctrlKey && !e.altKey) {
         const el = e.target;
@@ -178,13 +178,19 @@ export const ChartComponent = ({ chartId }) => {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
+  useEffect(() => {
+    const openPalette = () => setPalOpen(true);
+    window.addEventListener('qt-open-symbol-palette', openPalette);
+    return () => window.removeEventListener('qt-open-symbol-palette', openPalette);
+  }, []);
+
   useEffect(() => () => {
     if (timeframeWarningRef.current) {
       clearTimeout(timeframeWarningRef.current);
     }
   }, []);
 
-  const applySymbol = (sym) => { setSymbol(sym); handleApply(); };
+  const applySymbol = (sym) => { setSymbol(sym); setPalOpen(false); handleApply(); };
   // Data loader.
   const loadChartData = useCallback(async () => {
     try {
@@ -503,78 +509,107 @@ export const ChartComponent = ({ chartId }) => {
     return show;
   }
 
+  const surfaceClass = 'rounded-3xl border border-neutral-800 bg-neutral-950/80 px-6 py-6 shadow-[0_24px_60px_-40px_rgba(0,0,0,0.9)] backdrop-blur';
+
   return (
-    <>
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold text-neutral-100">Market snapshot</h2>
+        <p className="max-w-2xl text-sm text-neutral-400">
+          Adjust the timeframe, symbol, and window to plan your next move.
+        </p>
+      </div>
 
-      <div className="space-y-3 mb-4">
-        {rangeWarning && (
-          <div className="flex items-center gap-2 rounded-lg border border-amber-400/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-100">
-            <span className="text-lg">⚠️</span>
-            <span className="font-medium">{rangeWarning}</span>
-          </div>
-        )}
+      {rangeWarning && (
+        <div className="flex items-center gap-2 rounded-2xl border border-amber-500/40 bg-amber-500/15 px-4 py-3 text-sm text-amber-200">
+          <span aria-hidden className="text-lg">⚠️</span>
+          <span className="font-medium">{rangeWarning}</span>
+        </div>
+      )}
 
-        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/60 p-4 shadow-lg shadow-slate-950/20">
-          <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-            <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-end">
+      <div className={surfaceClass}>
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-end">
               <TimeframeSelect selected={interval} onChange={setInterval} />
-              <SymbolInput value={symbol} onChange={setSymbol} />
+              <div className="flex min-w-[10rem] flex-col gap-2">
+                <span className="text-[11px] uppercase tracking-[0.24em] text-neutral-500">Symbol</span>
+                <button
+                  type="button"
+                  onClick={() => setPalOpen(true)}
+                  className="inline-flex w-full items-center justify-between rounded-lg border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm font-semibold text-neutral-200 transition hover:border-neutral-500 hover:text-neutral-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500"
+                >
+                  <span className="uppercase tracking-wide">{symbol}</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                    className="h-4 w-4 text-neutral-500"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487 19.5 7.125M4.5 19.5l2.569-.428a2 2 0 0 0 1.093-.554L19.5 7.125a1.875 1.875 0 1 0-2.652-2.652L5.51 16.366a2 2 0 0 0-.554 1.093L4.5 19.5Z" />
+                  </svg>
+                </button>
+              </div>
               <DateRangePickerComponent dateRange={dateRange} setDateRange={setDateRange} />
             </div>
-            <div className="flex items-center gap-2 self-start">
-              <span className="text-xs uppercase tracking-[0.35em] text-slate-400">Refresh</span>
-              <button
-                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-sky-400/70 bg-sky-500/30 text-sky-50 transition hover:bg-sky-500/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300"
-                onClick={handleApply}
-                type="button"
-                title="Fetch latest data"
-                aria-label="Fetch latest data"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={1.5}
-                  className="h-5 w-5"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M4.5 12a7.5 7.5 0 0 1 12.618-5.303M19.5 12a7.5 7.5 0 0 1-12.618 5.303M8.25 8.25h-3v-3M15.75 15.75h3v3"
-                  />
-                </svg>
-              </button>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="text-left text-xs text-neutral-500">
+              <div className="font-semibold uppercase tracking-[0.24em] text-neutral-400">Refresh</div>
+              <div className="text-neutral-400">Apply your latest settings</div>
             </div>
+            <button
+              className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-neutral-700 bg-neutral-900 text-neutral-300 shadow-sm transition hover:border-neutral-500 hover:text-neutral-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500"
+              onClick={handleApply}
+              type="button"
+              title="Fetch latest data"
+              aria-label="Fetch latest data"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                className="h-5 w-5"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4.5 12a7.5 7.5 0 0 1 12.618-5.303M19.5 12a7.5 7.5 0 0 1-12.618 5.303M8.25 8.25h-3v-3M15.75 15.75h3v3"
+                />
+              </svg>
+            </button>
           </div>
         </div>
       </div>
 
-      <div className="flex space-x-4">
-        <div className="relative flex-1 h-[560px] overflow-hidden rounded-2xl border border-neutral-900 bg-neutral-950/80">
-          <div ref={chartContainerRef} className="h-full w-full bg-transparent" />
-          <button
-            type="button"
-            onClick={() => setPalOpen(true)}
-            className="absolute left-4 top-4 inline-flex h-9 items-center justify-center rounded-md border border-neutral-800 bg-neutral-950/90 px-3 text-sm font-medium text-neutral-200 hover:bg-neutral-900"
-            title="Open symbol presets (/)"
-          >
-            Presets
-          </button>
+      <div className={`${surfaceClass} relative h-[560px] overflow-hidden px-0 py-0`}>
+        <div ref={chartContainerRef} className="h-full w-full rounded-[28px] bg-neutral-950" />
+        <button
+          type="button"
+          onClick={() => setPalOpen(true)}
+          className="group absolute left-6 top-6 inline-flex items-center gap-2 rounded-full border border-neutral-700 bg-neutral-900/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.24em] text-neutral-300 shadow-sm transition hover:border-neutral-500 hover:text-neutral-100"
+          title="Open symbol presets (/)"
+        >
+          <span className="h-1.5 w-1.5 rounded-full bg-neutral-500 transition group-hover:bg-neutral-200" />
+          Presets
+        </button>
 
-          <SymbolPalette open={palOpen} onClose={() => setPalOpen(false)} onPick={applySymbol} />
-          <HotkeyHint />
-          {/* overlay */}
-          <LoadingOverlay
-            show={useBusyDelay(chartState?.overlayLoading || chartState?.signalsLoading || dataLoading)}
-            message={
-              chartState?.signalsLoading ? 'Generating signals…'
-              : chartState?.overlayLoading ? 'Loading overlays…'
-              : 'Loading chart…'
-            }
-          />
-        </div>
+        <SymbolPalette open={palOpen} onClose={() => setPalOpen(false)} onPick={applySymbol} />
+        <HotkeyHint />
+        {/* overlay */}
+        <LoadingOverlay
+          show={useBusyDelay(chartState?.overlayLoading || chartState?.signalsLoading || dataLoading)}
+          message={
+            chartState?.signalsLoading ? 'Generating signals…'
+            : chartState?.overlayLoading ? 'Loading overlays…'
+            : 'Loading chart…'
+          }
+        />
       </div>
-    </>
+    </div>
   )
 };

--- a/portal/frontend/src/components/ChartComponent/TimeframeSelectComponent.jsx
+++ b/portal/frontend/src/components/ChartComponent/TimeframeSelectComponent.jsx
@@ -38,14 +38,14 @@ export function TimeframeSelect({ selected, onChange }) {
 
   return (
     <div className="flex min-w-[13rem] flex-col gap-2">
-      <span className="text-[11px] uppercase tracking-[0.2em] text-neutral-300">Timeframe</span>
+      <span className="text-[11px] uppercase tracking-[0.24em] text-neutral-500">Timeframe</span>
       <div className="relative">
         <button
           type="button"
           onClick={toggle}
           aria-haspopup="listbox"
           aria-expanded={open}
-          className="flex w-full items-center justify-between rounded-lg border border-slate-600/60 bg-slate-900/50 px-3 py-2 text-sm font-semibold text-slate-100 transition hover:border-sky-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+          className="flex w-full items-center justify-between rounded-lg border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm font-semibold text-neutral-200 transition hover:border-neutral-500 hover:text-neutral-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500"
         >
           <span>{(activeOption?.label || activeOption?.value || '').toUpperCase()}</span>
           <svg
@@ -62,10 +62,10 @@ export function TimeframeSelect({ selected, onChange }) {
 
         <div
           role="listbox"
-          className={`absolute z-10 mt-2 w-full overflow-hidden rounded-xl border border-slate-700/70 bg-slate-900/95 shadow-lg backdrop-blur transition-all ${open ? 'max-h-80 opacity-100' : 'pointer-events-none max-h-0 opacity-0'}`}
+          className={`absolute z-40 mt-2 w-full overflow-hidden rounded-xl border border-neutral-800 bg-neutral-950/95 shadow-xl backdrop-blur transition-all ${open ? 'max-h-80 opacity-100' : 'pointer-events-none max-h-0 opacity-0'}`}
         >
-          <div className="divide-y divide-slate-800/80">
-            <div className="grid grid-cols-2 gap-px bg-slate-800/70 p-2">
+          <div className="divide-y divide-neutral-800">
+            <div className="grid grid-cols-2 gap-px bg-neutral-900 p-2">
               {options.filter(o => o.featured).map(option => {
                 const isActive = option.value === selected;
                 return (
@@ -73,7 +73,7 @@ export function TimeframeSelect({ selected, onChange }) {
                     key={option.value}
                     type="button"
                     onClick={() => handleSelect(option.value)}
-                    className={`rounded-lg px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400 ${isActive ? 'bg-sky-500/20 text-sky-100 ring-1 ring-sky-400/70' : 'text-slate-200 hover:bg-sky-500/10 hover:text-sky-100'}`}
+                    className={`rounded-lg px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500 ${isActive ? 'bg-neutral-800 text-neutral-50 ring-1 ring-neutral-600' : 'text-neutral-400 hover:bg-neutral-800 hover:text-neutral-100'}`}
                   >
                     {option.label}
                   </button>
@@ -89,43 +89,16 @@ export function TimeframeSelect({ selected, onChange }) {
                     key={option.value}
                     type="button"
                     onClick={() => handleSelect(option.value)}
-                    className={`flex items-center justify-between rounded-lg px-3 py-2 text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400 ${isActive ? 'bg-indigo-500/20 text-indigo-100 ring-1 ring-indigo-400/60' : 'text-slate-200 hover:bg-indigo-500/10 hover:text-indigo-100'}`}
+                    className={`flex items-center justify-between rounded-lg px-3 py-2 text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500 ${isActive ? 'bg-neutral-800 text-neutral-50 ring-1 ring-neutral-600' : 'text-neutral-400 hover:bg-neutral-800 hover:text-neutral-100'}`}
                   >
                     <span className="font-medium">{option.label}</span>
-                    <span className="text-xs uppercase tracking-[0.25em] text-slate-400">{option.value}</span>
+                    <span className="text-xs uppercase tracking-[0.25em] text-neutral-500">{option.value}</span>
                   </button>
                 );
               })}
             </div>
           </div>
         </div>
-      </div>
-    </div>
-  );
-}
-
-
-export function SymbolInput({ value, onChange, placeholder = 'Symbol' }) {
-  return (
-    <div className="flex flex-col gap-2 min-w-[10rem]">
-      <span className="text-[11px] uppercase tracking-[0.2em] text-neutral-400">Symbol</span>
-      <div className="relative flex items-center">
-        <span className="pointer-events-none absolute left-3 text-neutral-500">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="h-4 w-4">
-            <path strokeLinecap="round" strokeLinejoin="round" d="m19 19-3.5-3.5m1-4.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0Z" />
-          </svg>
-        </span>
-        <input
-          type="text"
-          inputMode="text"
-          spellCheck={false}
-          autoCapitalize="characters"
-          autoComplete="off"
-          className="w-40 rounded-md border border-neutral-800 bg-neutral-900/70 py-2 pl-9 pr-3 text-sm font-semibold uppercase tracking-wide text-neutral-100 outline-none transition focus:border-sky-400 focus:ring-1 focus:ring-sky-500/50"
-          value={value}
-          onChange={(e) => onChange(e.target.value.toUpperCase())}
-          placeholder={placeholder}
-        />
       </div>
     </div>
   );

--- a/portal/frontend/src/components/HotkeyHint.jsx
+++ b/portal/frontend/src/components/HotkeyHint.jsx
@@ -1,8 +1,8 @@
 export default function HotkeyHint() {
   return (
     <div className="fixed bottom-3 right-3 z-30">
-      <div className="rounded-md bg-black  border-neutral-700 text-white text-xs font-semibold px-2.5 py-1.5 shadow-lg">
-        <kbd className="px-1 py-0.5 rounded bg-neutral-800 border border-neutral-700">/</kbd>  Presets
+      <div className="rounded-md border border-neutral-800 bg-neutral-900/90 px-2.5 py-1.5 text-xs font-semibold text-neutral-300 shadow">
+        <kbd className="rounded border border-neutral-700 bg-neutral-900 px-1 py-0.5 text-[11px] text-neutral-200">/</kbd> Presets
       </div>
     </div>
   );

--- a/portal/frontend/src/components/IndicatorCard.jsx
+++ b/portal/frontend/src/components/IndicatorCard.jsx
@@ -1,7 +1,17 @@
 // src/components/IndicatorCard.jsx
 import React, { Fragment, useMemo, useState } from "react";
-import { Switch, Popover, PopoverButton, PopoverPanel, Transition } from "@headlessui/react";
-import { MoreHorizontal, Copy, Info, ChevronDown } from "lucide-react";
+import {
+  Switch,
+  Popover,
+  PopoverButton,
+  PopoverPanel,
+  Transition,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuItems,
+} from "@headlessui/react";
+import { MoreHorizontal, CopyPlus, FileJson, Sparkles, Trash2, Pencil } from "lucide-react";
 
 /**
  * IndicatorCard
@@ -30,6 +40,7 @@ export default function IndicatorCard({
   onToggle,
   onEdit,
   onDelete,
+  onClone,
   onGenerateSignals,
   onSelectColor,
   isGeneratingSignals = false,
@@ -77,18 +88,15 @@ export default function IndicatorCard({
   };
 
   return (
-    <div className="flex items-start justify-between gap-4 px-4 py-3 rounded-lg bg-neutral-900 shadow-lg">
-      {/* Left: title + pills */}
+    <div className="flex items-start justify-between gap-4 rounded-xl border border-neutral-800 bg-neutral-900/70 px-4 py-3 shadow-[0_12px_32px_-24px_rgba(0,0,0,0.9)]">
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <div className="font-medium text-white truncate" title={indicator?.name}>{indicator?.name}</div>
-
-          {/* Color selector */}
+          <div className="truncate font-medium text-neutral-100" title={indicator?.name}>{indicator?.name}</div>
           <Popover className="relative">
             {({ close }) => (
               <>
                 <PopoverButton
-                  className="h-4 w-4 rounded-sm border border-neutral-500 shadow-[inset_0_0_0_1px_rgba(255,255,255,.08)]"
+                  className="h-4 w-4 rounded-sm border border-neutral-700 shadow-inner"
                   style={{ backgroundColor: color }}
                   title="Set color"
                 />
@@ -100,12 +108,12 @@ export default function IndicatorCard({
                   leaveFrom="opacity-100 translate-y-0"
                   leaveTo="opacity-0 translate-y-1"
                 >
-                  <PopoverPanel className="absolute z-20 mt-2 rounded-md bg-neutral-800 p-2 shadow-lg ring-1 ring-black/20">
+                  <PopoverPanel className="absolute z-30 mt-2 rounded-md border border-neutral-800 bg-neutral-900 p-2 shadow-xl">
                     <div className="flex gap-2">
                       {colorSwatches.map((c) => (
                         <button
                           key={c}
-                          className="h-5 w-5 rounded-sm border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/40"
+                          className="h-5 w-5 rounded-sm border border-neutral-700 focus:outline-none focus:ring-2 focus:ring-neutral-500"
                           style={{ backgroundColor: c }}
                           onClick={() => {
                             onSelectColor?.(indicator.id, c);
@@ -121,21 +129,19 @@ export default function IndicatorCard({
             )}
           </Popover>
         </div>
-        <div className="text-sm text-gray-500">{indicator?.type}</div>
+        <div className="text-sm text-neutral-400">{indicator?.type}</div>
 
-        {/* Pills */}
         <div className="mt-1 flex flex-wrap gap-1">
           {essentials.map(([k, v]) => (
-            <span key={k} className="inline-flex items-center gap-1 rounded-full bg-neutral-800 text-neutral-300 border border-neutral-700 px-2 py-0.5 text-xs">
-              <span className="text-neutral-400">{k}</span>
+            <span key={k} className="inline-flex items-center gap-1 rounded-full border border-neutral-800 bg-neutral-950/60 px-2 py-0.5 text-xs text-neutral-300">
+              <span className="text-neutral-500">{k}</span>
               <span>={formatVal(v)}</span>
             </span>
           ))}
 
-          {/* Advanced fold */}
           {advanced.length > 0 && !showAdvanced && (
             <button
-              className="inline-flex items-center gap-1 rounded-full bg-neutral-800 text-blue-300 border border-neutral-700 px-2 py-0.5 text-xs hover:bg-neutral-700"
+              className="inline-flex items-center gap-1 rounded-full border border-neutral-800 bg-neutral-900 px-2 py-0.5 text-xs text-neutral-400 transition hover:border-neutral-600 hover:text-neutral-200"
               onClick={() => setShowAdvanced(true)}
             >
               +{advanced.length} more
@@ -146,13 +152,13 @@ export default function IndicatorCard({
         {showAdvanced && (
           <div className="mt-2 flex flex-wrap gap-1">
             {advanced.map(([k, v]) => (
-              <span key={k} className="inline-flex items-center gap-1 rounded-full bg-neutral-900 text-neutral-300 border border-neutral-700 px-2 py-0.5 text-xs">
+              <span key={k} className="inline-flex items-center gap-1 rounded-full border border-neutral-800 bg-neutral-950/60 px-2 py-0.5 text-xs text-neutral-300">
                 <span className="text-neutral-500">{k}</span>
                 <span>={formatVal(v)}</span>
               </span>
             ))}
             <button
-              className="inline-flex items-center gap-1 rounded-full bg-neutral-900 text-neutral-300 border border-neutral-700 px-2 py-0.5 text-xs hover:bg-neutral-800"
+              className="inline-flex items-center gap-1 rounded-full border border-neutral-800 bg-neutral-900 px-2 py-0.5 text-xs text-neutral-400 transition hover:border-neutral-600 hover:text-neutral-200"
               onClick={() => setShowAdvanced(false)}
             >
               Show less
@@ -161,34 +167,28 @@ export default function IndicatorCard({
         )}
       </div>
 
-      {/* Right: actions */}
-      <div className="flex items-center gap-3 shrink-0">
-        {/* Enable/disable */}
+      <div className="flex shrink-0 items-center gap-3 text-neutral-400">
         <Switch
           checked={!!indicator?.enabled}
           onChange={() => onToggle?.(indicator.id)}
-          className={`${indicator?.enabled ? "bg-indigo-500" : "bg-gray-600"} relative inline-flex h-6 w-11 items-center rounded-full mouse-pointer`}
+          className={`${indicator?.enabled ? 'bg-emerald-500' : 'bg-neutral-700'} relative inline-flex h-6 w-11 items-center rounded-full cursor-pointer transition`}
         >
-          <span className={`${indicator?.enabled ? "translate-x-6" : "translate-x-1"} inline-block h-4 w-4 transform rounded-full bg-white transition mouse-pointer`} />
+          <span className={`${indicator?.enabled ? 'translate-x-6' : 'translate-x-1'} inline-block h-4 w-4 transform rounded-full bg-white shadow transition`} />
         </Switch>
 
-        {/* Edit */}
         <button
           onClick={() => onEdit?.(indicator)}
-          className="text-gray-400 hover:text-white mouse-pointer"
-          title="Edit"
+          className="inline-flex items-center gap-1 rounded-full border border-neutral-700 bg-neutral-900 px-3 py-1 text-xs font-medium text-neutral-200 transition hover:border-neutral-500 hover:text-neutral-50"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.6" stroke="currentColor" className="size-6 mouse-pointer">
-            <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
-          </svg>
+          <Pencil className="size-3.5" />
+          Edit
         </button>
 
-        {/* Generate Signals */}
         <button
           type="button"
           onClick={() => onGenerateSignals?.(indicator.id)}
-          className={`relative flex h-8 w-8 items-center justify-center rounded-full border border-green-500/40 text-green-300 transition ${
-            disableSignalAction ? 'opacity-50 cursor-not-allowed' : 'hover:text-green-100 hover:border-green-400'
+          className={`relative inline-flex items-center gap-2 rounded-full border border-emerald-500/60 px-3 py-1 text-xs font-medium text-emerald-300 transition ${
+            disableSignalAction ? 'cursor-not-allowed opacity-40' : 'hover:border-emerald-400 hover:text-emerald-200'
           }`}
           title={isGeneratingSignals ? 'Generating…' : 'Generate signals'}
           disabled={disableSignalAction || isGeneratingSignals}
@@ -200,62 +200,70 @@ export default function IndicatorCard({
               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
             </svg>
           ) : (
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.6" stroke="currentColor" className="size-5">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15.91 11.672a.375.375 0 0 1 0 .656l-5.603 3.113a.375.375 0 0 1-.557-.328V8.887c0-.286.307-.466.557-.327l5.603 3.112Z" />
-            </svg>
-          )}
-        </button>
-
-        {/* Copy JSON */}
-        <button onClick={copyParams} className="text-neutral-400 hover:text-neutral-100" title="Copy params JSON">
-          <Copy className="size-5" />
-        </button>
-
-        {/* Delete with tiny confirm popover */}
-        <Popover className="relative">
-          {({ close }) => (
             <>
-              <PopoverButton className="text-red-400 hover:text-red-200" title="Delete">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.6" stroke="currentColor" className="size-6">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-                </svg>
-              </PopoverButton>
-              <Transition
-                as={Fragment}
-                enter="transition ease-out duration-100"
-                enterFrom="opacity-0 scale-95"
-                enterTo="opacity-100 scale-100"
-                leave="transition ease-in duration-75"
-                leaveFrom="opacity-100 scale-100"
-                leaveTo="opacity-0 scale-95"
-              >
-                <PopoverPanel className="absolute z-50 -top-2 right-0 -translate-y-full rounded-md border border-neutral-700 bg-neutral-900 shadow-xl p-1">
-                  <div className="flex items-center gap-1">
-                    <button
-                      onClick={() => { onDelete?.(indicator.id); close(); }}
-                      className="p-1 rounded hover:bg-green-600/20 text-green-400 hover:text-green-300"
-                      aria-label="Confirm delete"
-                    >
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="size-5">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5"/>
-                      </svg>
-                    </button>
-                    <PopoverButton
-                      aria-label="Cancel"
-                      className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-                    >
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="size-5">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                      </svg>
-                    </PopoverButton>
-                  </div>
-                  <div className="absolute -bottom-1 right-3 w-2 h-2 bg-neutral-900 border-b border-r border-neutral-700 rotate-45" />
-                </PopoverPanel>
-              </Transition>
+              <Sparkles className="size-3.5" />
+              Run
             </>
           )}
-        </Popover>
+        </button>
+
+        <Menu as="div" className="relative">
+          <MenuButton className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-neutral-800 bg-neutral-900 text-neutral-500 transition hover:border-neutral-600 hover:text-neutral-200">
+            <MoreHorizontal className="size-4" />
+          </MenuButton>
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-100"
+            enterFrom="opacity-0 translate-y-1"
+            enterTo="opacity-100 translate-y-0"
+            leave="transition ease-in duration-75"
+            leaveFrom="opacity-100 translate-y-0"
+            leaveTo="opacity-0 translate-y-1"
+          >
+            <MenuItems className="absolute right-0 z-40 mt-2 w-48 origin-top-right divide-y divide-neutral-800 overflow-hidden rounded-xl border border-neutral-800 bg-neutral-950/95 text-sm text-neutral-200 shadow-xl backdrop-blur">
+              <div className="p-1">
+                <MenuItem>
+                  {({ active }) => (
+                    <button
+                      type="button"
+                      onClick={() => onClone?.(indicator.id)}
+                      className={`${active ? 'bg-neutral-800 text-neutral-50' : ''} flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left`}
+                    >
+                      <CopyPlus className="size-4" />
+                      Duplicate indicator
+                    </button>
+                  )}
+                </MenuItem>
+                <MenuItem>
+                  {({ active }) => (
+                    <button
+                      type="button"
+                      onClick={copyParams}
+                      className={`${active ? 'bg-neutral-800 text-neutral-50' : ''} flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left`}
+                    >
+                      <FileJson className="size-4" />
+                      Copy params JSON
+                    </button>
+                  )}
+                </MenuItem>
+              </div>
+              <div className="p-1">
+                <MenuItem>
+                  {({ active }) => (
+                    <button
+                      type="button"
+                      onClick={() => onDelete?.(indicator.id)}
+                      className={`${active ? 'bg-rose-600/20 text-rose-200' : 'text-rose-300'} flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left`}
+                    >
+                      <Trash2 className="size-4" />
+                      Delete indicator
+                    </button>
+                  )}
+                </MenuItem>
+              </div>
+            </MenuItems>
+          </Transition>
+        </Menu>
       </div>
     </div>
   );

--- a/portal/frontend/src/components/IndicatorModal.v2.jsx
+++ b/portal/frontend/src/components/IndicatorModal.v2.jsx
@@ -103,6 +103,24 @@ export default function IndicatorModalV2({
     return keys;
   }, [typeMeta]);
 
+  useEffect(() => {
+    setParams((prev) => {
+      if (!prev || !intListKeys.size) return prev;
+      let changed = false;
+      const next = { ...prev };
+      intListKeys.forEach((key) => {
+        if (!(key in prev)) return;
+        const current = prev[key];
+        const display = typeof current === "string" ? current : listToString(current);
+        if (display !== current) {
+          next[key] = display;
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [intListKeys]);
+
   // 1) Load list of available types when opening
   useEffect(() => {
     if (!isOpen) return;
@@ -248,10 +266,9 @@ export default function IndicatorModalV2({
             inputMode="numeric"
             pattern="^[0-9\\s,;]*$"
             className="w-full rounded-lg border border-neutral-700/70 bg-neutral-900/60 px-3 py-2 text-sm focus:border-indigo-500/70 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-            value={listToString(val)}
+            value={typeof val === "string" ? val : listToString(val)}
             placeholder="e.g., 5, 10, 20"
             onChange={(e) => setParams((p) => ({ ...p, [key]: e.target.value }))}
-            onBlur={(e) => setParams((p) => ({ ...p, [key]: toIntList(e.target.value) }))}
           />
         ) : enumVals?.length ? (
           <select
@@ -300,10 +317,20 @@ export default function IndicatorModalV2({
     );
   };
 
+  const buildSubmitParams = () => {
+    const base = { ...params };
+    intListKeys.forEach((key) => {
+      if (base[key] !== undefined) {
+        base[key] = toIntList(base[key]);
+      }
+    });
+    return base;
+  };
+
   const handleSubmit = () => {
     if (!typeId) return setMetaErr("Please select a type.");
     if (!name.trim()) return setMetaErr("Please enter a name.");
-    onSave({ id: initial?.id, type: typeId, name, params });
+    onSave({ id: initial?.id, type: typeId, name, params: buildSubmitParams() });
   };
 
   const resetToDefaults = () => {
@@ -315,7 +342,7 @@ export default function IndicatorModalV2({
 
   const copyParams = async () => {
     try {
-      await navigator.clipboard.writeText(JSON.stringify(params, null, 2));
+      await navigator.clipboard.writeText(JSON.stringify(buildSubmitParams(), null, 2));
     } catch (e) {
       logger.error("copy_params_failed", e);
     }
@@ -345,9 +372,6 @@ export default function IndicatorModalV2({
             <DialogTitle className="text-lg font-semibold">
               {initial?.id ? "Edit Indicator" : "Create Indicator"}
             </DialogTitle>
-            <p className="mt-1 text-sm text-neutral-400">
-              Configure signal logic quickly with grouped essentials and one-click tools.
-            </p>
           </div>
 
           <div className="flex flex-col gap-6 px-6 py-6 lg:flex-row">

--- a/portal/frontend/src/components/IndicatorTab.jsx
+++ b/portal/frontend/src/components/IndicatorTab.jsx
@@ -52,7 +52,7 @@ const normalizeParams = (params) => {
 };
 
 // Manages the list of indicators and syncs enabled ones to the chart context
-export const IndicatorSection = ({ chartId }) => {
+export const IndicatorSection = ({ chartId, filterEnabledOnly = false, onStatsChange }) => {
   const [indicators, setIndicators] = useState([])
   const [modalOpen, setModalOpen] = useState(false)
   const [editing, setEditing] = useState(null)
@@ -281,10 +281,54 @@ export const IndicatorSection = ({ chartId }) => {
   const handleDelete = async (id) => {
     try {
       await deleteIndicator(id)
-      setIndicators(prev => prev.filter(i => i.id !== id))
+      setIndicators(prev => {
+        const next = prev.filter(i => i.id !== id)
+        queueMicrotask(() => { void refreshEnabledOverlays(next); })
+        return next
+      })
+      setIndColors(prev => {
+        if (!(id in prev)) return prev
+        const { [id]: _removed, ...rest } = prev
+        return rest
+      })
     } catch (e) {
       setError(e.message)
       logError('indicator_delete_failed', e)
+    }
+  }
+
+  const handleClone = async (id) => {
+    const original = indicators.find((ind) => ind.id === id)
+    if (!original) return
+
+    try {
+      const baseName = original.name || original.type || 'Indicator'
+      const taken = new Set(indicators.map((ind) => ind.name))
+      let attempt = 1
+      let candidate = `${baseName} copy`
+      while (taken.has(candidate)) {
+        attempt += 1
+        candidate = `${baseName} copy ${attempt}`
+      }
+
+      const clonePayload = {
+        type: original.type,
+        params: { ...original.params },
+        name: candidate,
+      }
+
+      const created = await createIndicator(clonePayload)
+      setIndicators(prev => {
+        const next = [...prev, created]
+        queueMicrotask(() => { void refreshEnabledOverlays(next); })
+        return next
+      })
+      if (indColors[original.id]) {
+        setIndColors(prev => ({ ...prev, [created.id]: prev[original.id] || indColors[original.id] }))
+      }
+    } catch (e) {
+      setError(e.message)
+      logError('indicator_clone_failed', e)
     }
   }
 
@@ -326,23 +370,31 @@ export const IndicatorSection = ({ chartId }) => {
     setIndColors(prev => ({ ...prev, [indicatorId]: color }));
   };
 
-  if (!chartState || !chartId) return <div className="text-red-500">Error: No chart state found</div>
-
   const isSignalsLoading = !!chartState?.signalsLoading
   const signalsLoadingFor = chartState?.signalsLoadingFor
+  const visibleIndicators = filterEnabledOnly ? indicators.filter(ind => ind.enabled) : indicators
+
+  useEffect(() => {
+    onStatsChange?.({
+      total: indicators.length,
+      enabled: indicators.filter(ind => ind.enabled).length,
+    })
+  }, [indicators, onStatsChange])
+
+  if (!chartState || !chartId) return <div className="text-red-500">Error: No chart state found</div>
 
   return (
     <div className="space-y-6">
       {error && (
-        <div className="relative rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-100 shadow-inner">
+        <div className="relative rounded-lg border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200 shadow-sm">
           <div className="pr-6">
-            <p className="font-medium text-red-200">Request failed</p>
-            <p className="mt-1 text-red-100">{error}</p>
+            <p className="font-medium text-rose-100">Request failed</p>
+            <p className="mt-1 text-rose-200">{error}</p>
           </div>
           <button
             type="button"
             onClick={() => setError(null)}
-            className="absolute right-3 top-3 text-red-200/80 hover:text-red-100"
+            className="absolute right-3 top-3 text-rose-300 transition hover:text-rose-100"
             aria-label="Dismiss error"
           >
             <X className="size-4" />
@@ -351,8 +403,8 @@ export const IndicatorSection = ({ chartId }) => {
       )}
 
       {isLoading && (
-        <div className="flex items-center gap-2 rounded-lg border border-neutral-800 bg-neutral-900/60 px-3 py-2 text-sm text-neutral-300">
-          <svg className="size-4 animate-spin text-blue-300" viewBox="0 0 24 24" role="status" aria-hidden="true">
+        <div className="flex items-center gap-2 rounded-lg border border-neutral-800 bg-neutral-900/70 px-3 py-2 text-sm text-neutral-400">
+          <svg className="size-4 animate-spin text-neutral-500" viewBox="0 0 24 24" role="status" aria-hidden="true">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
           </svg>
@@ -362,7 +414,7 @@ export const IndicatorSection = ({ chartId }) => {
 
       <button
         onClick={() => openEditModal()}
-        className="flex flex-col items-center w-full px-4 py-3 rounded-lg bg-neutral-900 text-neutral-400 hover:text-neutral-100 shadow-lg cursor-pointer transition-colors"
+        className="flex w-full cursor-pointer flex-col items-center rounded-lg border border-dashed border-neutral-800 bg-neutral-950/60 px-4 py-3 text-neutral-400 shadow-sm transition hover:border-neutral-600 hover:text-neutral-100"
       >
         {/* plus icon preserved */}
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6 mb-2">
@@ -373,7 +425,7 @@ export const IndicatorSection = ({ chartId }) => {
 
       {/* List of indicators */}
       <div className="space-y-1">
-          {indicators.map(indicator => {
+          {visibleIndicators.map(indicator => {
             const isGenerating = isSignalsLoading && signalsLoadingFor === indicator.id
             const disableSignals = isSignalsLoading && signalsLoadingFor !== indicator.id
             return (
@@ -384,6 +436,7 @@ export const IndicatorSection = ({ chartId }) => {
                 onToggle={toggleEnable}
                 onEdit={openEditModal}
                 onDelete={handleDelete}
+                onClone={handleClone}
                 onGenerateSignals={generateSignals}
                 onSelectColor={handleSelectColor}
                 colorSwatches={COLOR_SWATCHES}
@@ -394,8 +447,14 @@ export const IndicatorSection = ({ chartId }) => {
           })}
 
           {!isLoading && indicators.length === 0 && (
-            <div className="rounded-lg border border-dashed border-neutral-800 bg-neutral-900/40 px-4 py-6 text-center text-sm text-neutral-400">
+            <div className="rounded-lg border border-dashed border-neutral-800 bg-neutral-950/60 px-4 py-6 text-center text-sm text-neutral-500">
               No indicators yet. Create one to get started.
+            </div>
+          )}
+
+          {!isLoading && indicators.length > 0 && visibleIndicators.length === 0 && (
+            <div className="rounded-lg border border-neutral-800 bg-neutral-950/60 px-4 py-6 text-center text-sm text-neutral-500">
+              All active indicators are shown. Disable the filter to see archived ones.
             </div>
           )}
       </div>

--- a/portal/frontend/src/components/LoadingOverlay.jsx
+++ b/portal/frontend/src/components/LoadingOverlay.jsx
@@ -1,8 +1,8 @@
 export default function LoadingOverlay({ show, message = 'Loading…' }) {
   if (!show) return null;
   return (
-    <div className="absolute inset-0 z-10 grid place-items-center bg-black/35 backdrop-blur-sm">
-      <div className="flex items-center gap-3 text-neutral-100">
+    <div className="absolute inset-0 z-10 grid place-items-center bg-black/70 backdrop-blur">
+      <div className="flex items-center gap-3 text-neutral-300">
         <svg className="h-5 w-5 animate-spin" viewBox="0 0 24 24">
           <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" fill="none" opacity="0.25"/>
           <path d="M22 12a10 10 0 0 1-10 10" stroke="currentColor" strokeWidth="3" fill="none" />

--- a/portal/frontend/src/components/SymbolPalette.jsx
+++ b/portal/frontend/src/components/SymbolPalette.jsx
@@ -6,7 +6,13 @@ const FAV_KEY = 'qt.symbolFavorites';
 const loadFavs = () => {
   try { return JSON.parse(localStorage.getItem(FAV_KEY) || '[]'); } catch { return []; }
 };
-const saveFavs = (arr) => { try { localStorage.setItem(FAV_KEY, JSON.stringify(arr)); } catch {} };
+const saveFavs = (arr) => {
+  try {
+    localStorage.setItem(FAV_KEY, JSON.stringify(arr));
+  } catch (err) {
+    console.warn('symbol_favorites_persist_failed', err);
+  }
+};
 
 export default function SymbolPalette({ open, onClose, onPick }) {
   const [q, setQ] = useState('');
@@ -36,27 +42,38 @@ export default function SymbolPalette({ open, onClose, onPick }) {
     });
   };
 
+  const handleEnter = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const first = results[0];
+      if (first) {
+        onPick?.(first.s);
+      }
+    }
+  };
+
   if (!open) return null;
   return (
-    <div className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm" onClick={onClose}>
+    <div className="fixed inset-0 z-40 bg-black/60 backdrop-blur" onClick={onClose}>
       <div
-        className="mx-auto mt-24 w-[780px] max-w-[94vw] rounded-2xl bg-neutral-900/95 border border-neutral-700 shadow-2xl"
+        className="mx-auto mt-24 w-[780px] max-w-[94vw] rounded-2xl border border-neutral-800 bg-neutral-950/95 shadow-[0_32px_120px_-60px_rgba(0,0,0,0.9)] backdrop-blur"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="p-3 border-b border-neutral-700 flex items-center gap-2">
+        <div className="flex items-center gap-2 border-b border-neutral-800 p-3">
           <input
             autoFocus
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Search symbols or groups… try: metals, SPY, oil"
-            className="flex-1 bg-neutral-800/70 text-neutral-100 placeholder-neutral-400 px-3 py-2 rounded-lg outline-none"
+            onKeyDown={handleEnter}
+            className="flex-1 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm text-neutral-200 placeholder-neutral-500 outline-none transition focus:border-neutral-600 focus:bg-neutral-900"
           />
-          <span className="text-xs text-neutral-400">Press Enter to select</span>
+          <span className="text-xs text-neutral-500">Press Enter to select</span>
         </div>
 
         {!!favs.length && (
           <div className="max-h-[50vh] overflow-auto p-3 pt-2">
-            <div className="text-[11px] uppercase tracking-wide text-neutral-400 mb-1">Favorites</div>
+            <div className="mb-1 text-[11px] uppercase tracking-wide text-neutral-500">Favorites</div>
             {favs.map(s => {
               const x = flat.find(i => i.s === s);
               if (!x) return null;
@@ -73,10 +90,12 @@ export default function SymbolPalette({ open, onClose, onPick }) {
           ))}
         </div>
 
-        <div className="p-2 text-xs text-neutral-500 flex justify-between border-t border-neutral-800">
-          <span>Tip: press <kbd className="px-1 py-0.5 rounded bg-neutral-800 border border-neutral-700">/</kbd> to open anywhere</span>
-          <button onClick={onClose}
-                  className="px-2 py-1 rounded bg-neutral-800 border border-neutral-700 text-neutral-200">
+        <div className="flex justify-between border-t border-neutral-800 p-2 text-xs text-neutral-500">
+          <span>Tip: press <kbd className="rounded border border-neutral-700 bg-neutral-900 px-1 py-0.5 text-neutral-300">/</kbd> to open anywhere</span>
+          <button
+            onClick={onClose}
+            className="rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-neutral-300 transition hover:border-neutral-500 hover:text-neutral-100"
+          >
             Close
           </button>
         </div>
@@ -87,10 +106,10 @@ export default function SymbolPalette({ open, onClose, onPick }) {
 
 function Row({ x, onPick, onFav, fav }) {
   return (
-    <div className="group w-full px-3 py-2 rounded-lg hover:bg-neutral-800/60 transition flex justify-between items-start">
+    <div className="group flex w-full items-start justify-between rounded-lg px-3 py-2 transition hover:bg-neutral-900">
       <button onClick={() => onPick(x.s)} className="text-left">
-        <div className="text-neutral-100 font-medium">
-          {x.s} <span className="text-neutral-400">· {x.name}</span>
+        <div className="font-medium text-neutral-100">
+          {x.s} <span className="text-neutral-500">· {x.name}</span>
         </div>
         <div className="text-xs text-neutral-400">
           <span className="text-neutral-500">{x.group}</span> — {x.note}
@@ -100,9 +119,9 @@ function Row({ x, onPick, onFav, fav }) {
       <button
         onClick={() => onFav(x.s)}
         className={[
-          'ml-3 mt-1 h-6 w-6 rounded-full border flex items-center justify-center',
-          fav ? 'border-amber-400 bg-amber-500/20 text-amber-300'
-              : 'border-neutral-600 bg-neutral-800/60 text-neutral-300 group-hover:text-neutral-100',
+          'ml-3 mt-1 flex h-6 w-6 items-center justify-center rounded-full border text-sm transition',
+          fav ? 'border-amber-500/60 bg-amber-500/20 text-amber-300'
+              : 'border-neutral-700 bg-neutral-900 text-neutral-500 group-hover:border-neutral-500 group-hover:text-neutral-200',
         ].join(' ')}
         title={fav ? 'Unfavorite' : 'Favorite'}
       >

--- a/portal/frontend/src/components/TabManager.jsx
+++ b/portal/frontend/src/components/TabManager.jsx
@@ -2,10 +2,16 @@ import { useEffect, useMemo, useState } from 'react'
 import { IndicatorSection } from './IndicatorTab.jsx'
 import { createLogger } from '../utils/logger.js'
 
-const tabs = ['Indicators', 'Signals', 'Strategies']
+const tabs = [
+  { key: 'Indicators', label: 'Indicators' },
+  { key: 'Signals', label: 'Signals' },
+  { key: 'Strategies', label: 'Strategies' },
+]
 
 export const TabManager = ({ chartId }) => {
-  const [activeTab, setActiveTab] = useState(tabs[0])
+  const [activeTab, setActiveTab] = useState(tabs[0].key)
+  const [showEnabledOnly, setShowEnabledOnly] = useState(false)
+  const [indicatorStats, setIndicatorStats] = useState({ total: 0, enabled: 0 })
 
   const logger = useMemo(() => createLogger('TabManager', { chartId }), [chartId])
   const { info, debug } = logger
@@ -14,43 +20,102 @@ export const TabManager = ({ chartId }) => {
     debug('tab_manager_initialized', { activeTab })
   }, [activeTab, debug])
 
-  // Debug: log tab changes and chartId
-  const handleTabClick = (tab) => {
-    setActiveTab(tab)
-    info('tab_switched', { tab })
+  const handleTabClick = (tabKey) => {
+    setActiveTab(tabKey)
+    info('tab_switched', { tab: tabKey })
   }
 
+  const surfaceClass = 'rounded-3xl border border-neutral-800/70 bg-neutral-950/80 p-6 shadow-[0_18px_45px_-30px_rgba(0,0,0,0.9)]'
+
   return (
-    <div className="p-.5">
-      {/* Top Tab Bar */}
-      <div className="flex mb-4">
-        {tabs.map((tab) => (
-          <button
-            key={tab}
-            onClick={() => handleTabClick(tab)}
-            className={`px-4 py-2 -mb-px border-b-2 transition-all cursor-pointer ${
-              activeTab === tab
-                ? 'border-white text-white font-semibold rounded-xs'
-                : 'border-transparent text-white/25 hover:text-neutral-500 '
-            }`}
-          >
-            {tab}
-          </button>
-        ))}
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold text-neutral-100">Lab Console</h2>
+          <p className="text-xs uppercase tracking-[0.28em] text-neutral-500">QuantLab</p>
+        </div>
+        <div className="flex items-center gap-3 text-xs text-neutral-400">
+          <span className="rounded-full border border-neutral-800 bg-neutral-900/80 px-3 py-1 font-semibold text-neutral-200">
+            {indicatorStats.enabled} active
+          </span>
+          <span className="text-neutral-500">of {indicatorStats.total} indicators</span>
+        </div>
       </div>
 
-      {/* Tab Content */}
-      <div className="mt-1">
+      <div className="flex flex-wrap items-center gap-3">
+        {tabs.map((tab) => {
+          const isActive = activeTab === tab.key
+          return (
+            <button
+              key={tab.key}
+              onClick={() => handleTabClick(tab.key)}
+              className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500 ${
+                isActive
+                  ? 'border-neutral-500 bg-neutral-800 text-neutral-100 shadow'
+                  : 'border-transparent bg-neutral-900 text-neutral-500 hover:border-neutral-700 hover:text-neutral-100'
+              }`}
+              type="button"
+              aria-pressed={isActive}
+            >
+              <span className={`h-1.5 w-1.5 rounded-full ${isActive ? 'bg-neutral-200' : 'bg-neutral-700'}`} />
+              {tab.label}
+            </button>
+          )
+        })}
+
         {activeTab === 'Indicators' && (
-          <div className="">
-            <IndicatorSection chartId={chartId}/>
-          </div>
+          <label className="ml-auto inline-flex items-center gap-2 rounded-full border border-neutral-800 bg-neutral-950/70 px-3 py-1.5 text-xs text-neutral-400">
+            <input
+              type="checkbox"
+              className="h-3.5 w-3.5 rounded border-neutral-700 bg-neutral-900 text-neutral-100 focus:ring-neutral-500"
+              checked={showEnabledOnly}
+              onChange={(event) => setShowEnabledOnly(event.target.checked)}
+            />
+            Show enabled only
+          </label>
+        )}
+      </div>
+
+      <div className={surfaceClass}>
+        {activeTab === 'Indicators' && (
+          <IndicatorSection
+            chartId={chartId}
+            filterEnabledOnly={showEnabledOnly}
+            onStatsChange={setIndicatorStats}
+          />
         )}
         {activeTab === 'Signals' && (
-          <div className="">Signal section goes here.</div>
+          <div className="grid gap-3 text-sm text-neutral-400">
+            <div className="rounded-2xl border border-neutral-800 bg-neutral-900/70 px-5 py-6">
+              <div className="flex items-center justify-between text-xs uppercase tracking-[0.28em] text-neutral-500">
+                Queue
+                <span className="text-sm font-semibold tracking-normal text-neutral-200">0</span>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-neutral-800 bg-neutral-900/70 px-5 py-6 text-center text-sm font-semibold text-neutral-500">
+              No signals
+            </div>
+          </div>
         )}
         {activeTab === 'Strategies' && (
-          <div className="">Strategy section goes here.</div>
+          <div className="grid gap-3 text-sm text-neutral-400 sm:grid-cols-2">
+            <div className="rounded-2xl border border-neutral-800 bg-neutral-900/70 px-5 py-6">
+              <span className="text-xs uppercase tracking-[0.28em] text-neutral-500">Win rate</span>
+              <div className="mt-4 text-2xl font-semibold text-neutral-100">--</div>
+            </div>
+            <div className="rounded-2xl border border-neutral-800 bg-neutral-900/70 px-5 py-6">
+              <span className="text-xs uppercase tracking-[0.28em] text-neutral-500">PnL</span>
+              <div className="mt-4 text-2xl font-semibold text-neutral-100">--</div>
+            </div>
+            <div className="rounded-2xl border border-neutral-800 bg-neutral-900/70 px-5 py-6 sm:col-span-2">
+              <span className="text-xs uppercase tracking-[0.28em] text-neutral-500">Trade log</span>
+              <div className="mt-4 grid grid-cols-3 gap-3 text-center text-lg font-semibold text-neutral-200">
+                <span>--</span>
+                <span>--</span>
+                <span>--</span>
+              </div>
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/portal/frontend/src/components/indicatorSignals.js
+++ b/portal/frontend/src/components/indicatorSignals.js
@@ -3,7 +3,7 @@ import { createLogger } from '../utils/logger.js';
 const signalsLogger = createLogger('IndicatorSignals');
 
 export const hexToRgba = (hex, a = 0.18) => {
-  if (!hex || !hex.startsWith('#')) return `rgba(156,163,175,${a})`;
+  if (!hex || !hex.startsWith('#')) return `rgba(148,163,184,${a})`;
   const v = hex.slice(1);
   const n = v.length === 3
     ? v.split('').map(c => parseInt(c + c, 16))
@@ -25,10 +25,25 @@ export const applyIndicatorColors = (overlays = [], colors = {}) =>
       ? ov.payload.markers.map(m => (m ? { ...m, color } : m))
       : ov.payload.markers;
 
+    const bubbles = Array.isArray(ov.payload.bubbles)
+      ? ov.payload.bubbles.map(bubble => {
+          if (!bubble) return bubble;
+          const accentColor = bubble.accentColor ?? color;
+          const backgroundColor = bubble.backgroundColor ?? hexToRgba(color, 0.14);
+          const textColor = bubble.textColor ?? '#1f2937';
+          return {
+            ...bubble,
+            accentColor,
+            backgroundColor,
+            textColor,
+          };
+        })
+      : ov.payload.bubbles;
+
     const boxes = Array.isArray(ov.payload.boxes)
       ? ov.payload.boxes.map(b => {
           if (!b) return b;
-          return { ...b, color: hexToRgba(color, 0.1), border: { color: hexToRgba(color, 0.7), width: 1 } };
+          return { ...b, color: hexToRgba(color, 0.12), border: { color: hexToRgba(color, 0.45), width: 1 } };
         })
       : ov.payload.boxes;
 
@@ -50,6 +65,7 @@ export const applyIndicatorColors = (overlays = [], colors = {}) =>
         price_lines,
         markers,
         boxes,
+        bubbles,
         segments,
         polylines,
       },

--- a/portal/frontend/src/hooks/useFeedStatus.js
+++ b/portal/frontend/src/hooks/useFeedStatus.js
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createLogger } from '../utils/logger.js';
+
+const DATA_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+const INDICATOR_BASE = import.meta.env.REACT_APP_API_BASE_URL || DATA_BASE;
+
+const TIMEOUT_MS = 7000;
+
+const toISO = (date) => date.toISOString();
+
+async function probeDataFeed(signal, log) {
+  const now = new Date();
+  const end = toISO(now);
+  const start = toISO(new Date(now.getTime() - 60 * 60 * 1000));
+
+  try {
+    const res = await fetch(`${DATA_BASE}/api/candles`, {
+      signal,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ symbol: 'CL', timeframe: '15m', start, end }),
+    });
+
+    if (!res.ok) {
+      log.warn('data_probe_failed_status', { status: res.status });
+      return { status: 'offline', detail: `${res.status}` };
+    }
+
+    const payload = await res.json();
+    const candles = Array.isArray(payload?.candles) ? payload.candles : [];
+
+    if (!candles.length) {
+      log.info('data_probe_empty');
+      return { status: 'degraded', detail: 'No data' };
+    }
+
+    return { status: 'online', detail: `${candles.length} bars` };
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      log.warn('data_probe_timeout');
+      return { status: 'offline', detail: 'Timeout' };
+    }
+    log.error('data_probe_error', error);
+    return { status: 'offline', detail: error?.message || 'Error' };
+  }
+}
+
+async function probeIndicatorFeed(signal, log) {
+  try {
+    const res = await fetch(`${INDICATOR_BASE}/api/indicators-types/`, { signal });
+
+    if (!res.ok) {
+      log.warn('indicator_probe_failed_status', { status: res.status });
+      return { status: 'offline', detail: `${res.status}` };
+    }
+
+    const payload = await res.json();
+    const count = Array.isArray(payload) ? payload.length : 0;
+    return { status: 'online', detail: `${count} types` };
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      log.warn('indicator_probe_timeout');
+      return { status: 'offline', detail: 'Timeout' };
+    }
+    log.error('indicator_probe_error', error);
+    return { status: 'offline', detail: error?.message || 'Error' };
+  }
+}
+
+const PROBES = [
+  {
+    key: 'data',
+    label: 'Market data',
+    runner: probeDataFeed,
+  },
+  {
+    key: 'indicators',
+    label: 'Indicator API',
+    runner: probeIndicatorFeed,
+  },
+];
+
+export function useFeedStatus({ refreshMs = 60000 } = {}) {
+  const logger = useMemo(() => createLogger('FeedStatus'), []);
+  const [statuses, setStatuses] = useState(() =>
+    PROBES.map((p) => ({ key: p.key, label: p.label, status: 'checking', detail: null }))
+  );
+
+  const runProbes = useCallback(async () => {
+    logger.info('probe_start');
+    setStatuses((prev) => prev.map((s) => ({ ...s, status: 'checking' })));
+
+    const results = await Promise.all(
+      PROBES.map(async (probe) => {
+        const scoped = logger.child({ probe: probe.key });
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+        try {
+          const outcome = await probe.runner(controller.signal, scoped);
+          return { key: probe.key, label: probe.label, ...outcome };
+        } finally {
+          clearTimeout(timer);
+        }
+      })
+    );
+
+    setStatuses(results);
+    logger.info('probe_complete', { results });
+  }, [logger]);
+
+  useEffect(() => {
+    runProbes();
+
+    if (!refreshMs) return undefined;
+
+    const id = setInterval(runProbes, refreshMs);
+    return () => clearInterval(id);
+  }, [runProbes, refreshMs]);
+
+  return {
+    statuses,
+    refresh: runProbes,
+    isChecking: statuses.some((s) => s.status === 'checking'),
+  };
+}
+
+export default useFeedStatus;

--- a/portal/frontend/src/index.css
+++ b/portal/frontend/src/index.css
@@ -1,4 +1,29 @@
 @import "tailwindcss";
+
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: #050507;
+  color: #f4f4f5;
+}
+
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  margin: 0;
+  min-height: 100%;
+  background-color: #050507;
+  color: #f4f4f5;
+}
+
+#root {
+  min-height: 100vh;
+  background: radial-gradient(120% 120% at 50% 0%, rgba(36, 36, 40, 0.55) 0%, rgba(5, 5, 7, 0.95) 52%, #050507 100%);
+}
+
 #tv-attr-logo {
   display: none !important;
 }


### PR DESCRIPTION
## Summary
- shift the QuantLab shell, chart workspace, and global styling to a dark gray palette with refreshed status badges and controls
- expand indicator management with active-count reporting, an enabled-only filter, clone support, and a streamlined action menu
- stabilize list-style parameter editing in the indicator modal by keeping inputs as strings and parsing them on save

## Testing
- npm run lint *(fails: upstream vendor bundles and generated dependencies still violate existing lint rules outside this change set)*

------
https://chatgpt.com/codex/tasks/task_e_68d3234df0b08331992b770ced372029