### PR TITLE
Refactor breakout confirmation logic

### DIFF
--- a/portal/backend/service/indicator_service.py
+++ b/portal/backend/service/indicator_service.py
@@ -364,6 +364,7 @@ def generate_signals_for_instance(
 
     rule_config: Dict[str, Any] = dict(config or {})
     rule_config.setdefault("pivot_breakout_confirmation_bars", 3)
+    rule_config.setdefault("market_profile_breakout_confirmation_bars", 1)
     rule_config.setdefault("symbol", sym)
 
     if isinstance(inst, MarketProfileIndicator) and "rule_payloads" not in rule_config:

--- a/src/signals/rules/breakout.py
+++ b/src/signals/rules/breakout.py
@@ -1,0 +1,134 @@
+"""Shared helpers for breakout confirmation tracking across rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+
+class BreakoutConfig(Protocol):
+    """Protocol describing breakout confirmation configuration."""
+
+    confirmation_bars: int
+    early_confirmation_window: int
+    early_confirmation_distance_pct: float
+
+
+@dataclass
+class BreakoutRunState:
+    """Mutable tracking state for breakout confirmation windows."""
+
+    active_side: Optional[str] = None
+    candidate_start_pos: Optional[int] = None
+    consecutive: int = 0
+    max_distance: float = 0.0
+    run_confirmed: bool = False
+    run_emitted: bool = False
+
+
+@dataclass(frozen=True)
+class BreakoutEvaluationResult:
+    """Outcome of processing a single candle for breakout confirmation."""
+
+    ready: bool
+    just_confirmed: bool
+    accelerated: bool
+    start_position: Optional[int]
+    consecutive: int
+    active_side: Optional[str]
+
+
+def reset_breakout_state(state: BreakoutRunState) -> None:
+    """Reset a breakout state to its initial values."""
+
+    state.active_side = None
+    state.candidate_start_pos = None
+    state.consecutive = 0
+    state.max_distance = 0.0
+    state.run_confirmed = False
+    state.run_emitted = False
+
+
+def mark_breakout_emitted(state: BreakoutRunState) -> None:
+    """Mark the current breakout run as emitted to avoid duplicates."""
+
+    state.run_emitted = True
+
+
+def update_breakout_state(
+    state: BreakoutRunState,
+    *,
+    side: Optional[str],
+    clearance: float,
+    position: int,
+    level_price: float,
+    config: BreakoutConfig,
+) -> BreakoutEvaluationResult:
+    """Update a breakout state with the latest candle classification.
+
+    Parameters
+    ----------
+    state:
+        Mutable tracking state shared across candles.
+    side:
+        "above" or "below" when the candle is fully outside the level, otherwise
+        any other value is treated as neutral and resets the run.
+    clearance:
+        The maximum distance between the candle and the level in the breakout
+        direction.
+    position:
+        Zero-based index of the processed candle within the evaluated window.
+    level_price:
+        Price of the level being evaluated.
+    config:
+        Breakout confirmation configuration providing confirmation and early
+        acceleration thresholds.
+    """
+
+    if side not in {"above", "below"}:
+        reset_breakout_state(state)
+        return BreakoutEvaluationResult(
+            ready=False,
+            just_confirmed=False,
+            accelerated=False,
+            start_position=None,
+            consecutive=0,
+            active_side=None,
+        )
+
+    if state.active_side != side:
+        state.active_side = side
+        state.candidate_start_pos = position
+        state.consecutive = 1
+        state.max_distance = max(0.0, float(clearance))
+        state.run_confirmed = False
+        state.run_emitted = False
+    else:
+        state.consecutive += 1
+        state.max_distance = max(state.max_distance, float(clearance))
+
+    ready = state.consecutive >= max(1, int(config.confirmation_bars))
+    accelerated = False
+
+    if not ready and state.candidate_start_pos is not None:
+        threshold = abs(float(level_price)) * float(config.early_confirmation_distance_pct)
+        if threshold > 0:
+            bars_since_start = position - state.candidate_start_pos + 1
+            if bars_since_start <= max(1, int(config.early_confirmation_window)):
+                if state.max_distance >= threshold:
+                    ready = True
+                    accelerated = True
+
+    just_confirmed = False
+    if ready and not state.run_confirmed:
+        state.run_confirmed = True
+        just_confirmed = True
+
+    return BreakoutEvaluationResult(
+        ready=ready and not state.run_emitted,
+        just_confirmed=just_confirmed,
+        accelerated=accelerated,
+        start_position=state.candidate_start_pos,
+        consecutive=state.consecutive,
+        active_side=state.active_side,
+    )

--- a/src/signals/rules/market_profile.py
+++ b/src/signals/rules/market_profile.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence
 
 import pandas as pd
 
 from indicators.market_profile import MarketProfileIndicator
+from signals.rules.breakout import (
+    BreakoutRunState,
+    mark_breakout_emitted,
+    reset_breakout_state,
+    update_breakout_state,
+)
 from signals.rules.patterns import (
     SignalPattern,
     assign_rule_metadata,
@@ -20,6 +27,26 @@ log = logging.getLogger("MarketProfileRules")
 _BREAKOUT_CACHE_KEY = "market_profile_breakouts"
 _BREAKOUT_CACHE_INITIALISED = "_market_profile_breakouts_initialised"
 _BREAKOUT_READY_FLAG = "_market_profile_breakouts_ready"
+
+
+@dataclass(frozen=True)
+class MarketProfileBreakoutConfig:
+    """Configuration for Market Profile breakout confirmations."""
+
+    confirmation_bars: int = 1
+    early_confirmation_window: int = 3
+    early_confirmation_distance_pct: float = 0.01
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass guard
+        if self.confirmation_bars < 1:
+            raise ValueError("confirmation_bars must be >= 1")
+        if self.early_confirmation_window < 1:
+            raise ValueError("early_confirmation_window must be >= 1")
+        if self.early_confirmation_distance_pct < 0:
+            raise ValueError("early_confirmation_distance_pct must be >= 0")
+
+
+_DEFAULT_BREAKOUT_CONFIG = MarketProfileBreakoutConfig()
 
 
 def _as_timestamp(value: Any, tz: Optional[str]) -> Optional[pd.Timestamp]:
@@ -52,6 +79,57 @@ def _value_area_identifier(value_area: Mapping[str, Any]) -> Optional[str]:
 def _compute_confidence(distance_pct: float) -> float:
     scaled = abs(distance_pct) * 5.0
     return max(0.1, min(scaled, 1.0))
+
+
+def _resolve_breakout_config(context: Mapping[str, Any]) -> MarketProfileBreakoutConfig:
+    confirmation = context.get(
+        "market_profile_breakout_confirmation_bars",
+        _DEFAULT_BREAKOUT_CONFIG.confirmation_bars,
+    )
+    try:
+        confirmation = int(confirmation)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        confirmation = _DEFAULT_BREAKOUT_CONFIG.confirmation_bars
+    if confirmation < 1:
+        confirmation = _DEFAULT_BREAKOUT_CONFIG.confirmation_bars
+
+    early_window = context.get(
+        "market_profile_breakout_early_window",
+        _DEFAULT_BREAKOUT_CONFIG.early_confirmation_window,
+    )
+    try:
+        early_window = int(early_window)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        early_window = _DEFAULT_BREAKOUT_CONFIG.early_confirmation_window
+    if early_window < 1:
+        early_window = _DEFAULT_BREAKOUT_CONFIG.early_confirmation_window
+
+    early_pct = context.get(
+        "market_profile_breakout_early_distance_pct",
+        _DEFAULT_BREAKOUT_CONFIG.early_confirmation_distance_pct,
+    )
+    try:
+        early_pct = float(early_pct)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        early_pct = _DEFAULT_BREAKOUT_CONFIG.early_confirmation_distance_pct
+    if early_pct < 0:
+        early_pct = _DEFAULT_BREAKOUT_CONFIG.early_confirmation_distance_pct
+
+    resolved = MarketProfileBreakoutConfig(
+        confirmation_bars=confirmation,
+        early_confirmation_window=early_window,
+        early_confirmation_distance_pct=early_pct,
+    )
+    log.debug(
+        (
+            "mp_brk | config_resolved | confirmation_bars=%d | early_window=%d "
+            "| early_pct=%.5f"
+        ),
+        resolved.confirmation_bars,
+        resolved.early_confirmation_window,
+        resolved.early_confirmation_distance_pct,
+    )
+    return resolved
 
 
 def _value_area_breakout_evaluator(context: Mapping[str, Any], value_area: Mapping[str, Any]) -> List[Dict[str, Any]]:
@@ -102,24 +180,28 @@ def _value_area_breakout_evaluator(context: Mapping[str, Any], value_area: Mappi
     min_age = pd.Timedelta(hours=max(min_age_hours, 0.0))
 
     session_id = _value_area_identifier(value_area)
+    config = _resolve_breakout_config(context)
+
     log.debug(
-        "mp_brk | evaluating | session=%s | mode=%s | bars=%d | vah=%.5f | val=%.5f | min_age=%s",
+        "mp_brk | evaluating | session=%s | mode=%s | bars=%d | vah=%.5f | val=%.5f | min_age=%s | confirmation=%d",
         session_id,
         mode,
         len(df),
         vah,
         val,
         min_age,
+        config.confirmation_bars,
     )
 
     value_area_range = float(vah - val)
     value_area_mid = float((vah + val) / 2.0)
     breakouts: List[Dict[str, Any]] = []
+    simulate_current_only = restrict_to_last
+    vah_state = BreakoutRunState()
+    val_state = BreakoutRunState()
+    last_index = len(df) - 1
 
     for idx in range(1, len(df)):
-        if restrict_to_last and idx != len(df) - 1:
-            continue
-
         prev_bar = df.iloc[idx - 1]
         current_bar = df.iloc[idx]
 
@@ -146,18 +228,6 @@ def _value_area_breakout_evaluator(context: Mapping[str, Any], value_area: Mappi
             )
             continue
 
-        prev_inside = val <= prev_close <= vah
-        if not prev_inside:
-            log.debug(
-                "mp_brk | skip_bar | reason=prev_outside | session=%s | idx=%d | prev_close=%.5f | vah=%.5f | val=%.5f",
-                session_id,
-                idx,
-                prev_close,
-                vah,
-                val,
-            )
-            continue
-
         ts = pd.Timestamp(df.index[idx])
         if start_ts is not None and ts - start_ts < min_age:
             log.debug(
@@ -170,6 +240,8 @@ def _value_area_breakout_evaluator(context: Mapping[str, Any], value_area: Mappi
                 min_age,
             )
             continue
+
+        prev_inside = val <= prev_close <= vah
 
         def _build_meta(level_price: float, direction: str, level_type: str) -> Dict[str, Any]:
             clearance = curr_close - level_price
@@ -214,35 +286,98 @@ def _value_area_breakout_evaluator(context: Mapping[str, Any], value_area: Mappi
             }
             return meta
 
-        detected = False
         if curr_close > vah:
-            breakouts.append(_build_meta(vah, "above", "VAH"))
-            detected = True
-            log.debug(
-                "mp_brk | detected | direction=above | session=%s | idx=%d | prev_close=%.5f | curr_close=%.5f | vah=%.5f | val=%.5f",
-                session_id,
-                idx,
-                prev_close,
-                curr_close,
-                vah,
-                val,
-            )
+            if prev_inside or vah_state.active_side == "above":
+                result = update_breakout_state(
+                    vah_state,
+                    side="above",
+                    clearance=curr_close - vah,
+                    position=idx,
+                    level_price=vah,
+                    config=config,
+                )
+                if result.ready:
+                    if not (simulate_current_only and idx != last_index):
+                        meta = _build_meta(vah, "above", "VAH")
+                        meta.update(
+                            {
+                                "confirmation_bars_required": config.confirmation_bars,
+                                "bars_closed_beyond_level": result.consecutive,
+                                "accelerated_confirmation": result.accelerated,
+                            }
+                        )
+                        if result.start_position is not None:
+                            meta["breakout_start_bar_index"] = result.start_position
+                            try:
+                                meta["breakout_start_index_label"] = df.index[result.start_position]
+                            except Exception:  # pragma: no cover - defensive
+                                pass
+
+                        breakouts.append(meta)
+                        mark_breakout_emitted(vah_state)
+                        log.debug(
+                            (
+                                "mp_brk | detected | direction=above | session=%s | idx=%d "
+                                "| bars=%d | accelerated=%s"
+                            ),
+                            session_id,
+                            idx,
+                            result.consecutive,
+                            result.accelerated,
+                        )
+                        if restrict_to_last:
+                            break
+            else:
+                reset_breakout_state(vah_state)
+        else:
+            if vah_state.active_side is not None:
+                reset_breakout_state(vah_state)
 
         if curr_close < val:
-            breakouts.append(_build_meta(val, "below", "VAL"))
-            detected = True
-            log.debug(
-                "mp_brk | detected | direction=below | session=%s | idx=%d | prev_close=%.5f | curr_close=%.5f | vah=%.5f | val=%.5f",
-                session_id,
-                idx,
-                prev_close,
-                curr_close,
-                vah,
-                val,
-            )
+            if prev_inside or val_state.active_side == "below":
+                result = update_breakout_state(
+                    val_state,
+                    side="below",
+                    clearance=val - curr_close,
+                    position=idx,
+                    level_price=val,
+                    config=config,
+                )
+                if result.ready and not (simulate_current_only and idx != last_index):
+                    meta = _build_meta(val, "below", "VAL")
+                    meta.update(
+                        {
+                            "confirmation_bars_required": config.confirmation_bars,
+                            "bars_closed_beyond_level": result.consecutive,
+                            "accelerated_confirmation": result.accelerated,
+                        }
+                    )
+                    if result.start_position is not None:
+                        meta["breakout_start_bar_index"] = result.start_position
+                        try:
+                            meta["breakout_start_index_label"] = df.index[result.start_position]
+                        except Exception:  # pragma: no cover - defensive
+                            pass
 
-        if detected and restrict_to_last:
-            break
+                    breakouts.append(meta)
+                    mark_breakout_emitted(val_state)
+                    log.debug(
+                        (
+                            "mp_brk | detected | direction=below | session=%s | idx=%d "
+                            "| bars=%d | accelerated=%s"
+                        ),
+                        session_id,
+                        idx,
+                        result.consecutive,
+                        result.accelerated,
+                    )
+                    if restrict_to_last:
+                        break
+            else:
+                reset_breakout_state(val_state)
+        else:
+            if val_state.active_side is not None:
+                reset_breakout_state(val_state)
 
     if breakouts:
         log.debug(

--- a/src/signals/rules/pivot.py
+++ b/src/signals/rules/pivot.py
@@ -11,6 +11,12 @@ import pandas as pd
 
 from indicators.pivot_level import Level, PivotLevelIndicator
 from signals.base import BaseSignal
+from signals.rules.breakout import (
+    BreakoutRunState,
+    mark_breakout_emitted,
+    reset_breakout_state,
+    update_breakout_state,
+)
 from signals.rules.patterns import assign_rule_metadata
 
 
@@ -220,12 +226,7 @@ def _evaluate_level(
     last_idx_position = len(closes) - 1
     simulate_current_only = mode in {"sim", "live"}
 
-    consecutive = 0
-    candidate_start_pos: Optional[int] = None
-    candidate_max_distance = 0.0
-    active_side: Optional[str] = None
-    run_emitted = False
-    run_confirmed = False
+    state = BreakoutRunState()
     confirmed_side: Optional[str] = None
     current_run_prior_confirmed_side: Optional[str] = None
     results: List[Dict[str, Any]] = []
@@ -235,51 +236,33 @@ def _evaluate_level(
         sides.append(side)
 
         if side in {"at", "straddle"}:
-            if active_side is not None and run_confirmed:
-                confirmed_side = active_side
-            consecutive = 0
-            candidate_start_pos = None
-            candidate_max_distance = 0.0
-            active_side = None
-            run_emitted = False
-            run_confirmed = False
+            if state.active_side is not None and state.run_confirmed:
+                confirmed_side = state.active_side
+            reset_breakout_state(state)
             current_run_prior_confirmed_side = None
             continue
 
-        if active_side != side:
-            if active_side is not None and run_confirmed:
-                confirmed_side = active_side
-            active_side = side
-            candidate_start_pos = position
-            consecutive = 1
-            candidate_max_distance = clearance
-            run_emitted = False
-            run_confirmed = False
+        if state.active_side is not None and state.active_side != side and state.run_confirmed:
+            confirmed_side = state.active_side
+
+        if state.active_side != side:
             current_run_prior_confirmed_side = confirmed_side
-        else:
-            consecutive += 1
-            candidate_max_distance = max(candidate_max_distance, clearance)
 
-        breakout_start_pos = candidate_start_pos
+        result = update_breakout_state(
+            state,
+            side=side if side in {"above", "below"} else None,
+            clearance=clearance,
+            position=position,
+            level_price=level_price,
+            config=config,
+        )
 
-        if breakout_start_pos is None or run_emitted:
-            continue
+        if result.just_confirmed and result.active_side is not None:
+            confirmed_side = result.active_side
 
-        accelerated = False
-        ready = consecutive >= confirmation_bars
-        if not ready:
-            bars_since_start = position - breakout_start_pos + 1
-            threshold = abs(level_price) * early_distance_pct
-            if threshold > 0 and bars_since_start <= early_window:
-                if candidate_max_distance >= threshold:
-                    ready = True
-                    accelerated = True
+        breakout_start_pos = result.start_position
 
-        if ready and not run_confirmed:
-            run_confirmed = True
-            confirmed_side = active_side
-
-        if not ready:
+        if breakout_start_pos is None or not result.ready:
             continue
 
         if simulate_current_only and position != last_idx_position:
@@ -291,6 +274,7 @@ def _evaluate_level(
         last_bar = df.loc[breakout_end_idx]
 
         prior_confirmed_side = current_run_prior_confirmed_side
+        active_side = result.active_side
         if prior_confirmed_side == "above" and active_side == "below":
             detected_level_kind: Optional[str] = "support"
         elif prior_confirmed_side == "below" and active_side == "above":
@@ -303,7 +287,7 @@ def _evaluate_level(
                 prior_confirmed_side,
                 active_side,
             )
-            run_emitted = True
+            mark_breakout_emitted(state)
             continue
 
         meta: Dict[str, Any] = {
@@ -312,14 +296,14 @@ def _evaluate_level(
             "level_price": level_price,
             "breakout_direction": active_side,
             "confirmation_bars_required": confirmation_bars,
-            "bars_closed_beyond_level": consecutive,
+            "bars_closed_beyond_level": result.consecutive,
             "breakout_start": _to_datetime(breakout_start_idx),
             "level_lookback": getattr(level, "lookback", None),
             "level_timeframe": getattr(level, "timeframe", None),
             "level_first_touched": _to_datetime(getattr(level, "first_touched", None)),
             "trigger_close": float(last_bar["close"]),
             "trigger_time": _to_datetime(breakout_end_idx),
-            "accelerated_confirmation": accelerated,
+            "accelerated_confirmation": result.accelerated,
             "prior_confirmed_side": prior_confirmed_side,
             "trigger_bar_index": position,
             "trigger_index_label": breakout_end_idx,
@@ -337,7 +321,7 @@ def _evaluate_level(
         )
 
         results.append(meta)
-        run_emitted = True
+        mark_breakout_emitted(state)
 
     if not results:
         log.debug(

--- a/tests/test_signals/test_market_profile_rules.py
+++ b/tests/test_signals/test_market_profile_rules.py
@@ -46,6 +46,7 @@ def sample_context(sample_market_profile_df):
         "symbol": "TEST",
         "mode": "backtest",
         "market_profile_breakout_min_age_hours": 0,
+        "market_profile_breakout_confirmation_bars": 1,
     }
 
 
@@ -63,11 +64,77 @@ def test_breakout_evaluator_detects_multiple_events(sample_context, sample_value
     assert first["trigger_time"] == sample_market_profile_df.index[2].to_pydatetime()
     assert first["prev_close"] == pytest.approx(sample_market_profile_df.iloc[1]["close"])
     assert first["trigger_open"] == pytest.approx(sample_market_profile_df.iloc[2]["open"])
+    assert first["bars_closed_beyond_level"] == 1
+    assert first["confirmation_bars_required"] == 1
+    assert not first["accelerated_confirmation"]
 
     assert second["breakout_direction"] == "below"
     assert second["trigger_bar_index"] == 5
     assert second["trigger_time"] == sample_market_profile_df.index[5].to_pydatetime()
     assert second["trigger_close"] == pytest.approx(sample_market_profile_df.iloc[5]["close"])
+    assert second["bars_closed_beyond_level"] == 1
+    assert second["confirmation_bars_required"] == 1
+    assert not second["accelerated_confirmation"]
+
+
+def test_breakout_evaluator_respects_confirmation_setting(sample_context, sample_value_area, sample_market_profile_df):
+    sample_context["market_profile_breakout_confirmation_bars"] = 2
+
+    metas = _value_area_breakout_evaluator(sample_context, sample_value_area)
+    assert len(metas) == 2
+
+    metas = sorted(metas, key=lambda meta: meta["trigger_bar_index"])
+    above, below = metas
+
+    assert above["breakout_direction"] == "above"
+    assert above["trigger_bar_index"] == 3
+    assert above["bars_closed_beyond_level"] == 2
+    assert above["confirmation_bars_required"] == 2
+    assert not above["accelerated_confirmation"]
+    assert above["breakout_start_bar_index"] == 2
+    assert above["breakout_start_index_label"] == sample_market_profile_df.index[2]
+
+    assert below["breakout_direction"] == "below"
+    assert below["trigger_bar_index"] == 6
+    assert below["bars_closed_beyond_level"] == 2
+    assert below["confirmation_bars_required"] == 2
+    assert not below["accelerated_confirmation"]
+    assert below["breakout_start_bar_index"] == 5
+    assert below["breakout_start_index_label"] == sample_market_profile_df.index[5]
+
+
+def test_breakout_evaluator_flags_accelerated_confirmation(sample_value_area):
+    index = pd.date_range("2025-01-03 09:30", periods=5, freq="15min", tz="UTC")
+    data = {
+        "open": [100.0, 100.4, 101.2, 101.5, 101.7],
+        "high": [100.4, 100.8, 101.8, 102.0, 102.2],
+        "low": [99.8, 100.1, 101.0, 101.2, 101.4],
+        "close": [100.1, 100.6, 101.6, 101.9, 101.8],
+        "volume": [900, 950, 980, 990, 995],
+    }
+    df = pd.DataFrame(data, index=index)
+    indicator = MarketProfileIndicator(df)
+    context = {
+        "indicator": indicator,
+        "df": df,
+        "symbol": "TEST",
+        "mode": "backtest",
+        "market_profile_breakout_min_age_hours": 0,
+        "market_profile_breakout_confirmation_bars": 3,
+        "market_profile_breakout_early_window": 2,
+        "market_profile_breakout_early_distance_pct": 0.001,
+    }
+
+    value_area = dict(sample_value_area)
+    value_area.update({"VAH": 101.0, "VAL": 99.0, "start": index[0] - pd.Timedelta(days=2), "end": index[-1]})
+
+    metas = _value_area_breakout_evaluator(context, value_area)
+    assert len(metas) == 1
+    meta = metas[0]
+    assert meta["breakout_direction"] == "above"
+    assert meta["trigger_bar_index"] == 3
+    assert meta["bars_closed_beyond_level"] == 2
+    assert meta["accelerated_confirmation"]
 
 
 def test_breakout_evaluator_live_mode_only_reports_latest(sample_value_area):
@@ -97,6 +164,37 @@ def test_breakout_evaluator_live_mode_only_reports_latest(sample_value_area):
     meta = metas[0]
     assert meta["trigger_bar_index"] == len(df) - 1
     assert meta["breakout_direction"] == "above"
+
+
+def test_breakout_evaluator_live_mode_honours_confirmation(sample_value_area):
+    index = pd.date_range("2025-01-04 09:30", periods=4, freq="15min", tz="UTC")
+    data = {
+        "open": [100.0, 100.3, 101.1, 101.4],
+        "high": [100.4, 100.9, 101.5, 101.9],
+        "low": [99.8, 100.0, 100.9, 101.1],
+        "close": [100.1, 100.8, 101.4, 101.6],
+        "volume": [800, 820, 840, 860],
+    }
+    df = pd.DataFrame(data, index=index)
+    indicator = MarketProfileIndicator(df)
+    context = {
+        "indicator": indicator,
+        "df": df,
+        "symbol": "TEST",
+        "mode": "live",
+        "market_profile_breakout_min_age_hours": 0,
+        "market_profile_breakout_confirmation_bars": 2,
+    }
+
+    value_area = dict(sample_value_area)
+    value_area.update({"start": index[0] - pd.Timedelta(days=2), "end": index[-1]})
+
+    metas = _value_area_breakout_evaluator(context, value_area)
+    assert len(metas) == 1
+    meta = metas[0]
+    assert meta["trigger_bar_index"] == len(df) - 1
+    assert meta["bars_closed_beyond_level"] == 2
+    assert meta["confirmation_bars_required"] == 2
 
 
 def test_retest_rule_emits_retests_for_cached_breakouts(sample_context, sample_value_area):


### PR DESCRIPTION
## Summary
- add shared breakout state helpers for tracking confirmation and acceleration
- update pivot and market profile breakout rules to use shared helpers and expose confirmation metadata
- extend market profile tests for multi-bar confirmation scenarios and set service defaults for confirmation bars

## Testing
- pytest tests/test_signals/test_market_profile_rules.py *(skipped: requires pandas)*
- pytest tests/test_signals/test_pivot_breakout_rule.py *(skipped: requires pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68db20afcca0833192bd038ab7adb671