### PR TITLE
Adjust market profile retest scope and overlays

### DIFF
--- a/portal/frontend/src/App.jsx
+++ b/portal/frontend/src/App.jsx
@@ -136,7 +136,7 @@ function AppShell({ chartId }) {
   return (
     <div className="min-h-screen bg-[#14171f] bg-[radial-gradient(circle_at_top,_var(--accent-gradient-spot)_0%,_rgba(20,23,31,1)_55%)] text-slate-100">
         <header className="sticky top-0 z-30 border-b border-white/5 bg-[#1c1f2b]/90 backdrop-blur">
-          <div className="mx-auto flex max-w-7xl flex-col gap-5 px-6 py-6 md:flex-row md:items-center md:justify-between">
+          <div className="mx-auto flex max-w-[1600px] flex-col gap-5 px-8 py-6 md:flex-row md:items-center md:justify-between">
             <div className="space-y-1">
               <div className="flex items-center gap-3 text-lg font-semibold text-slate-100">
                 <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-[color:var(--accent-alpha-15)] text-[color:var(--accent-text-soft)]">QT</span>
@@ -158,7 +158,7 @@ function AppShell({ chartId }) {
           </div>
         </header>
 
-        <main className="mx-auto max-w-7xl space-y-20 px-6 py-12">
+        <main className="mx-auto max-w-[1600px] space-y-20 px-8 py-12">
           <section id="quantlab" className="space-y-10">
             <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
               <SectionHeading
@@ -236,7 +236,7 @@ function AppShell({ chartId }) {
         </main>
 
         <footer className="border-t border-white/5 bg-[#181b25]/80 py-8">
-          <div className="mx-auto flex max-w-7xl flex-col gap-4 px-6 text-xs text-slate-400 sm:flex-row sm:items-center sm:justify-between">
+          <div className="mx-auto flex max-w-[1600px] flex-col gap-4 px-8 text-xs text-slate-400 sm:flex-row sm:items-center sm:justify-between">
             <p>QuantTrad Portal — unified intelligence for research, ops, and reporting.</p>
             <div className="flex flex-wrap items-center gap-3 text-xs text-slate-300">
               <a

--- a/src/indicators/market_profile.py
+++ b/src/indicators/market_profile.py
@@ -295,8 +295,9 @@ class MarketProfileIndicator(BaseIndicator):
         use_merged: bool = True,
         merge_threshold: float = 0.60,
         min_merge: int = 3,
-        include_touches: bool = True, 
-        time_fmt="business_day"
+        include_touches: bool = True,
+        time_fmt="business_day",
+        extend_boxes_to_chart_end: bool = True,
     ) -> Dict[str, Any]:
         """
         Return overlays in your portal's expected shape:
@@ -307,6 +308,7 @@ class MarketProfileIndicator(BaseIndicator):
         Notes:
         • 'time' is when the line starts; renderer should extend to the right.
         • Color will be recolored uniformly per-indicator on the client.
+        • Value-area boxes extend to the chart end unless extend_boxes_to_chart_end=False.
         """
         if plot_df is None or plot_df.empty:
             return {"price_lines": [], "markers": []}
@@ -365,10 +367,17 @@ class MarketProfileIndicator(BaseIndicator):
             # start_iso = _ts_iso(start_ts)
             start_str = fmt_time(start_ts) # either 'YYYY-MM-DD' or unix seconds
             
-            # Boxes span from start to chart end
-            end_ts = pd.to_datetime(prof.get("end") or prof.get("end_date") or chart_end, utc=True)
-            if end_ts > chart_end:
+            if extend_boxes_to_chart_end:
                 end_ts = chart_end
+            else:
+                end_ts = pd.to_datetime(
+                    prof.get("end") or prof.get("end_date") or chart_end,
+                    utc=True,
+                )
+                if end_ts > chart_end:
+                    end_ts = chart_end
+            if end_ts < start_ts:
+                end_ts = start_ts
 
             out_boxes.append({
                 "x1": _to_unix_s(start_ts),   # epoch seconds

--- a/src/indicators/market_profile.py
+++ b/src/indicators/market_profile.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from typing import Dict, List, Tuple, Set, Any
+from typing import Dict, List, Tuple, Set, Any, Optional
 import matplotlib.dates as mdates
 from matplotlib.patches import Rectangle
 from mplfinance.plotting import make_addplot
@@ -45,7 +45,14 @@ class MarketProfileIndicator(BaseIndicator):
     """
     NAME = "market_profile"
 
-    def __init__(self, df: pd.DataFrame, bin_size: float = 0.1, mode: str = "tpo", interval: str = "30m"):
+    def __init__(
+        self,
+        df: pd.DataFrame,
+        bin_size: float = 0.1,
+        mode: str = "tpo",
+        interval: str = "30m",
+        extend_value_area_to_chart_end: bool = True,
+    ):
         super().__init__(df)
         self.bin_size = bin_size
         self.mode = mode
@@ -53,9 +60,18 @@ class MarketProfileIndicator(BaseIndicator):
         self.daily_profiles = self._compute_daily_profiles()
         self.merged_profiles = []
         self.interval = interval
+        self.extend_value_area_to_chart_end = bool(extend_value_area_to_chart_end)
 
     @classmethod
-    def from_context(cls, provider, ctx: DataContext, bin_size: float = 0.1, mode: str = "tpo", interval: str = "30m"):
+    def from_context(
+        cls,
+        provider,
+        ctx: DataContext,
+        bin_size: float = 0.1,
+        mode: str = "tpo",
+        interval: str = "30m",
+        extend_value_area_to_chart_end: bool = True,
+    ):
         """
         Fetches OHLCV from provider and constructs the indicator.
         Raises ValueError if no data is available.
@@ -67,7 +83,13 @@ class MarketProfileIndicator(BaseIndicator):
         if df is None or df.empty:
             raise ValueError(f"MarketProfileIndicator: No data available for {ctx.symbol} [{ctx.interval}] after ingest")
 
-        return cls(df=df, bin_size=bin_size, mode=mode)
+        return cls(
+            df=df,
+            bin_size=bin_size,
+            mode=mode,
+            interval=interval,
+            extend_value_area_to_chart_end=extend_value_area_to_chart_end,
+        )
 
     def _compute_daily_profiles(self) -> List[Dict[str, float]]:
         """
@@ -297,7 +319,7 @@ class MarketProfileIndicator(BaseIndicator):
         min_merge: int = 3,
         include_touches: bool = True,
         time_fmt="business_day",
-        extend_boxes_to_chart_end: bool = True,
+        extend_boxes_to_chart_end: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Return overlays in your portal's expected shape:
@@ -308,7 +330,7 @@ class MarketProfileIndicator(BaseIndicator):
         Notes:
         • 'time' is when the line starts; renderer should extend to the right.
         • Color will be recolored uniformly per-indicator on the client.
-        • Value-area boxes extend to the chart end unless extend_boxes_to_chart_end=False.
+        • Value-area boxes extend to the chart end unless extend_value_area_to_chart_end=False.
         """
         if plot_df is None or plot_df.empty:
             return {"price_lines": [], "markers": []}
@@ -318,6 +340,11 @@ class MarketProfileIndicator(BaseIndicator):
         plot_df.index = pd.to_datetime(plot_df.index, utc=True)
 
         fmt_time = _to_business_day_str if time_fmt == "business_day" else _to_unix_s
+
+        if extend_boxes_to_chart_end is None:
+            extend_boxes_to_chart_end = getattr(self, "extend_value_area_to_chart_end", True)
+        else:
+            extend_boxes_to_chart_end = bool(extend_boxes_to_chart_end)
 
         if use_merged:
             # compute merged profiles once if needed

--- a/src/signals/rules/market_profile.py
+++ b/src/signals/rules/market_profile.py
@@ -424,7 +424,7 @@ def _detect_value_area_retest(
     slice_start = 0
     value_area_start_index = breakout_meta.get("value_area_start_index")
     if isinstance(value_area_start_index, int):
-        slice_start = max(0, min(value_area_start_index, start_idx))
+        slice_start = max(0, value_area_start_index)
     else:
         value_area_start = breakout_meta.get("value_area_start")
         if value_area_start is not None:
@@ -438,7 +438,7 @@ def _detect_value_area_retest(
                         va_start_ts = va_start_ts.tz_convert(tz)  # type: ignore[arg-type]
                 positions = df.index.get_indexer([va_start_ts], method="nearest")
                 if positions.size and positions[0] >= 0:
-                    slice_start = max(0, min(int(positions[0]), start_idx))
+                    slice_start = max(0, int(positions[0]))
             except Exception:
                 log.debug(
                     "mp_retest | warn | reason=value_area_start_unresolved | session=%s | start=%s",
@@ -447,6 +447,17 @@ def _detect_value_area_retest(
                 )
 
     df_scope = df.iloc[slice_start:]
+    breakout_scope = breakout_meta
+    if slice_start > 0 and not df_scope.empty:
+        breakout_scope = dict(breakout_meta)
+        for key in ("trigger_bar_index", "breakout_start_bar_index"):
+            idx_val = breakout_scope.get(key)
+            if isinstance(idx_val, int):
+                adjusted = idx_val - slice_start
+                if adjusted < 0:
+                    breakout_scope.pop(key, None)
+                else:
+                    breakout_scope[key] = adjusted
     if df_scope.empty:
         log.debug(
             "mp_retest | skip | reason=scope_empty | session=%s | slice_start=%s",
@@ -457,7 +468,7 @@ def _detect_value_area_retest(
 
     result = _pivot_detect_retest(
         df_scope,
-        breakout_meta,
+        breakout_scope,
         tolerance_pct=tolerance_pct,
         max_bars=max_bars,
         min_bars=min_bars,

--- a/src/signals/rules/market_profile.py
+++ b/src/signals/rules/market_profile.py
@@ -222,6 +222,37 @@ def _value_area_breakout_evaluator(context: Mapping[str, Any], value_area: Mappi
         value_area.get("end_date"), tz
     )
 
+    chart_end_ts: Optional[pd.Timestamp] = None
+    if len(df.index):
+        try:
+            chart_end_ts = pd.Timestamp(df.index.max())
+            if tz is not None:
+                if chart_end_ts.tzinfo is None:
+                    chart_end_ts = chart_end_ts.tz_localize(tz)  # type: ignore[arg-type]
+                else:
+                    chart_end_ts = chart_end_ts.tz_convert(tz)  # type: ignore[arg-type]
+        except Exception:  # pragma: no cover - defensive
+            chart_end_ts = None
+
+    extend_override = context.get("market_profile_extend_value_area_to_chart_end")
+    if extend_override is None:
+        extend_to_chart_end = bool(getattr(indicator, "extend_value_area_to_chart_end", True))
+    elif isinstance(extend_override, str):
+        extend_to_chart_end = extend_override.strip().lower() not in {"false", "0", "no", "off"}
+    else:
+        extend_to_chart_end = bool(extend_override)
+
+    if extend_to_chart_end and chart_end_ts is not None:
+        end_ts = chart_end_ts
+    elif end_ts is None and chart_end_ts is not None:
+        end_ts = chart_end_ts
+
+    if end_ts is not None and chart_end_ts is not None and end_ts > chart_end_ts:
+        end_ts = chart_end_ts
+
+    if end_ts is not None and start_ts is not None and end_ts < start_ts:
+        end_ts = start_ts
+
     try:
         min_age_hours = float(context.get("market_profile_breakout_min_age_hours", 24.0))
     except (TypeError, ValueError):
@@ -446,7 +477,41 @@ def _detect_value_area_retest(
                     value_area_start,
                 )
 
-    df_scope = df.iloc[slice_start:]
+    slice_end = len(df)
+    value_area_end_index = breakout_meta.get("value_area_end_index")
+    if isinstance(value_area_end_index, int):
+        slice_end = min(len(df), max(0, value_area_end_index + 1))
+    else:
+        value_area_end = breakout_meta.get("value_area_end")
+        if value_area_end is not None:
+            try:
+                tz = getattr(df.index, "tz", None)
+                va_end_ts = pd.Timestamp(value_area_end)
+                if tz is not None:
+                    if va_end_ts.tzinfo is None:
+                        va_end_ts = va_end_ts.tz_localize(tz)  # type: ignore[arg-type]
+                    else:
+                        va_end_ts = va_end_ts.tz_convert(tz)  # type: ignore[arg-type]
+                positions = df.index.get_indexer([va_end_ts], method="nearest")
+                if positions.size and positions[0] >= 0:
+                    slice_end = min(len(df), int(positions[0]) + 1)
+            except Exception:
+                log.debug(
+                    "mp_retest | warn | reason=value_area_end_unresolved | session=%s | end=%s",
+                    breakout_meta.get("value_area_id"),
+                    value_area_end,
+                )
+
+    if slice_end <= slice_start:
+        log.debug(
+            "mp_retest | skip | reason=invalid_scope | session=%s | slice_start=%s | slice_end=%s",
+            breakout_meta.get("value_area_id"),
+            slice_start,
+            slice_end,
+        )
+        return None
+
+    df_scope = df.iloc[slice_start:slice_end]
     breakout_scope = breakout_meta
     if slice_start > 0 and not df_scope.empty:
         breakout_scope = dict(breakout_meta)
@@ -454,10 +519,18 @@ def _detect_value_area_retest(
             idx_val = breakout_scope.get(key)
             if isinstance(idx_val, int):
                 adjusted = idx_val - slice_start
-                if adjusted < 0:
+                if adjusted < 0 or adjusted >= len(df_scope):
                     breakout_scope.pop(key, None)
                 else:
                     breakout_scope[key] = adjusted
+    elif slice_end < len(df) and not df_scope.empty:
+        breakout_scope = dict(breakout_meta)
+
+    if breakout_scope is not breakout_meta and not df_scope.empty:
+        for key in ("trigger_bar_index", "breakout_start_bar_index"):
+            idx_val = breakout_scope.get(key)
+            if isinstance(idx_val, int) and idx_val >= len(df_scope):
+                breakout_scope.pop(key, None)
     if df_scope.empty:
         log.debug(
             "mp_retest | skip | reason=scope_empty | session=%s | slice_start=%s",

--- a/tests/test_indicators/test_market_profile_indicator.py
+++ b/tests/test_indicators/test_market_profile_indicator.py
@@ -310,3 +310,40 @@ def test_to_lightweight_can_limit_box_to_profile_end(dummy_df):
     assert payload["boxes"], "Expected at least one value-area box"
     box = payload["boxes"][0]
     assert box["x2"] == int(end.timestamp())
+
+
+@pytest.mark.unit
+def test_to_lightweight_inherits_extend_flag_from_indicator(dummy_df):
+    mpi = MarketProfileIndicator(
+        dummy_df,
+        bin_size=1.0,
+        mode="tpo",
+        extend_value_area_to_chart_end=False,
+    )
+
+    start = pd.Timestamp("2025-01-02 09:30", tz="UTC")
+    end = start + pd.Timedelta(hours=2)
+    chart_end = end + pd.Timedelta(hours=3)
+
+    mpi.daily_profiles = [
+        {
+            "start_date": start,
+            "end_date": end,
+            "VAL": 95.0,
+            "VAH": 105.0,
+            "POC": 100.0,
+        }
+    ]
+
+    plot_idx = pd.date_range(start=start, end=chart_end, freq="30min", tz="UTC")
+    plot_df = pd.DataFrame({"open": [100.0] * len(plot_idx)}, index=plot_idx)
+
+    payload = mpi.to_lightweight(
+        plot_df,
+        use_merged=False,
+        include_touches=False,
+    )
+
+    assert payload["boxes"], "Expected at least one value-area box"
+    box = payload["boxes"][0]
+    assert box["x2"] == int(end.timestamp())

--- a/tests/test_indicators/test_market_profile_indicator.py
+++ b/tests/test_indicators/test_market_profile_indicator.py
@@ -245,3 +245,68 @@ def test_to_overlays_using_merge(dummy_df):
 
     # We expect 2 overlays (VAH, VAL) for that merged session
     assert len(overlays) == 2
+
+
+@pytest.mark.unit
+def test_to_lightweight_extends_boxes_to_chart_end_by_default(dummy_df):
+    mpi = MarketProfileIndicator(dummy_df, bin_size=1.0, mode="tpo")
+
+    start = pd.Timestamp("2025-01-01 10:00", tz="UTC")
+    end = start + pd.Timedelta(hours=2)
+    chart_end = end + pd.Timedelta(hours=2)
+
+    mpi.daily_profiles = [
+        {
+            "start_date": start,
+            "end_date": end,
+            "VAL": 99.0,
+            "VAH": 101.0,
+            "POC": 100.0,
+        }
+    ]
+
+    plot_idx = pd.date_range(start=start, end=chart_end, freq="30min", tz="UTC")
+    plot_df = pd.DataFrame({"open": [100.0] * len(plot_idx)}, index=plot_idx)
+
+    payload = mpi.to_lightweight(
+        plot_df,
+        use_merged=False,
+        include_touches=False,
+    )
+
+    assert payload["boxes"], "Expected at least one value-area box"
+    box = payload["boxes"][0]
+    assert box["x2"] == int(chart_end.timestamp())
+
+
+@pytest.mark.unit
+def test_to_lightweight_can_limit_box_to_profile_end(dummy_df):
+    mpi = MarketProfileIndicator(dummy_df, bin_size=1.0, mode="tpo")
+
+    start = pd.Timestamp("2025-01-01 10:00", tz="UTC")
+    end = start + pd.Timedelta(hours=1)
+    chart_end = end + pd.Timedelta(hours=3)
+
+    mpi.daily_profiles = [
+        {
+            "start_date": start,
+            "end_date": end,
+            "VAL": 99.0,
+            "VAH": 101.0,
+            "POC": 100.0,
+        }
+    ]
+
+    plot_idx = pd.date_range(start=start, end=chart_end, freq="30min", tz="UTC")
+    plot_df = pd.DataFrame({"open": [100.0] * len(plot_idx)}, index=plot_idx)
+
+    payload = mpi.to_lightweight(
+        plot_df,
+        use_merged=False,
+        include_touches=False,
+        extend_boxes_to_chart_end=False,
+    )
+
+    assert payload["boxes"], "Expected at least one value-area box"
+    box = payload["boxes"][0]
+    assert box["x2"] == int(end.timestamp())

--- a/tests/test_signals/test_market_profile_rules.py
+++ b/tests/test_signals/test_market_profile_rules.py
@@ -77,6 +77,11 @@ def test_breakout_evaluator_detects_multiple_events(sample_context, sample_value
     assert second["confirmation_bars_required"] == 1
     assert not second["accelerated_confirmation"]
 
+    chart_end = sample_market_profile_df.index[-1].to_pydatetime()
+    for meta in metas:
+        assert meta["value_area_end"] == chart_end
+        assert meta["value_area_end_index"] == len(sample_market_profile_df) - 1
+
 
 def test_breakout_evaluator_respects_confirmation_setting(sample_context, sample_value_area, sample_market_profile_df):
     sample_context["market_profile_breakout_confirmation_bars"] = 2
@@ -136,6 +141,65 @@ def test_breakout_evaluator_flags_accelerated_confirmation(sample_value_area):
     assert meta["trigger_bar_index"] == 3
     assert meta["bars_closed_beyond_level"] == 2
     assert meta["accelerated_confirmation"]
+
+
+def test_breakout_evaluator_extends_value_area_end_to_chart_close(sample_market_profile_df):
+    indicator = MarketProfileIndicator(sample_market_profile_df)
+    context = {
+        "indicator": indicator,
+        "df": sample_market_profile_df,
+        "symbol": "TEST",
+        "mode": "backtest",
+        "market_profile_breakout_min_age_hours": 0,
+    }
+
+    truncated_end = sample_market_profile_df.index[3]
+    value_area = {
+        "start": sample_market_profile_df.index[0],
+        "end": truncated_end,
+        "VAH": 102.0,
+        "VAL": 98.0,
+        "POC": 100.0,
+    }
+
+    metas = _value_area_breakout_evaluator(context, value_area)
+    assert metas, "Expected breakout metadata"
+    expected_end = sample_market_profile_df.index[-1].to_pydatetime()
+    expected_index = len(sample_market_profile_df) - 1
+    for meta in metas:
+        assert meta["value_area_end"] == expected_end
+        assert meta["value_area_end_index"] == expected_index
+
+
+def test_breakout_evaluator_respects_indicator_extend_flag(sample_market_profile_df):
+    indicator = MarketProfileIndicator(
+        sample_market_profile_df,
+        extend_value_area_to_chart_end=False,
+    )
+    context = {
+        "indicator": indicator,
+        "df": sample_market_profile_df,
+        "symbol": "TEST",
+        "mode": "backtest",
+        "market_profile_breakout_min_age_hours": 0,
+    }
+
+    truncated_end = sample_market_profile_df.index[3]
+    value_area = {
+        "start": sample_market_profile_df.index[0],
+        "end": truncated_end,
+        "VAH": 102.0,
+        "VAL": 98.0,
+        "POC": 100.0,
+    }
+
+    metas = _value_area_breakout_evaluator(context, value_area)
+    assert metas, "Expected breakout metadata"
+    expected_end = truncated_end.to_pydatetime()
+    expected_index = 3
+    for meta in metas:
+        assert meta["value_area_end"] == expected_end
+        assert meta["value_area_end_index"] == expected_index
 
 
 def test_breakout_evaluator_live_mode_only_reports_latest(sample_value_area):
@@ -283,3 +347,40 @@ def test_detect_value_area_retest_respects_value_area_start_index():
     assert retest is not None, "Expected a retest within the scoped window"
     assert retest["bars_since_breakout"] == 1
     assert retest["time"] == index[5].to_pydatetime()
+
+
+def test_detect_value_area_retest_respects_value_area_end_index():
+    index = pd.date_range("2025-03-02 09:30", periods=7, freq="15min", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [206.2, 206.3, 206.6, 206.9, 207.4, 207.0, 207.1],
+            "high": [206.4, 206.5, 206.9, 207.2, 207.7, 207.3, 207.2],
+            "low": [206.0, 206.1, 206.4, 206.8, 207.1, 206.7, 206.9],
+            "close": [206.3, 206.4, 206.8, 207.05, 207.4, 207.05, 207.15],
+        },
+        index=index,
+    )
+
+    breakout_meta = {
+        "level_price": 207.2,
+        "breakout_direction": "above",
+        "trigger_bar_index": 4,
+        "trigger_time": index[4].to_pydatetime(),
+        "trigger_index_label": index[4],
+        "value_area_start_index": 1,
+        "value_area_start": index[1].to_pydatetime(),
+        "value_area_end_index": 4,
+        "value_area_end": index[4].to_pydatetime(),
+        "value_area_id": "session-456",
+    }
+
+    retest = _detect_value_area_retest(
+        df,
+        breakout_meta,
+        tolerance_pct=0.0015,
+        max_bars=10,
+        min_bars=1,
+        mode="backtest",
+    )
+
+    assert retest is None

--- a/tests/test_signals/test_market_profile_rules.py
+++ b/tests/test_signals/test_market_profile_rules.py
@@ -5,6 +5,7 @@ pd = pytest.importorskip("pandas")
 from indicators.market_profile import MarketProfileIndicator
 from signals.rules.market_profile import (
     _value_area_breakout_evaluator,
+    _detect_value_area_retest,
     market_profile_breakout_rule,
     market_profile_retest_rule,
     _BREAKOUT_CACHE_KEY,
@@ -245,3 +246,40 @@ def test_retest_rule_ignores_distant_closes():
 
     retests = market_profile_retest_rule(context, value_area)
     assert retests == []
+
+
+def test_detect_value_area_retest_respects_value_area_start_index():
+    index = pd.date_range("2025-03-01 09:30", periods=6, freq="15min", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [106.2, 106.3, 106.6, 106.9, 107.2, 107.05],
+            "high": [106.4, 106.5, 106.8, 107.1, 107.6, 107.3],
+            "low": [106.0, 106.1, 106.4, 106.8, 107.0, 107.02],
+            "close": [106.3, 106.4, 106.7, 107.0, 107.45, 107.15],
+        },
+        index=index,
+    )
+
+    breakout_meta = {
+        "level_price": 107.2,
+        "breakout_direction": "above",
+        "trigger_bar_index": 4,
+        "trigger_time": index[4].to_pydatetime(),
+        "trigger_index_label": index[4],
+        "value_area_start_index": 2,
+        "value_area_start": index[2].to_pydatetime(),
+        "value_area_id": "session-123",
+    }
+
+    retest = _detect_value_area_retest(
+        df,
+        breakout_meta,
+        tolerance_pct=0.0015,
+        max_bars=10,
+        min_bars=1,
+        mode="backtest",
+    )
+
+    assert retest is not None, "Expected a retest within the scoped window"
+    assert retest["bars_since_breakout"] == 1
+    assert retest["time"] == index[5].to_pydatetime()


### PR DESCRIPTION
## Summary
- add an `extend_boxes_to_chart_end` flag to the market profile lightweight payload so value-area boxes reach the chart end by default but can be capped at the session
- tighten the market profile retest window so scanning begins at the value-area start and keeps breakout indices aligned after trimming
- add unit coverage for the new overlay extension toggle and the retest window scoping

## Testing
- pytest tests/test_indicators/test_market_profile_indicator.py -k to_lightweight_extends *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68dc3c17d6e08331bd90d8b09d7e7a80