### PR TITLE
Limit market profile breakouts to session window

### DIFF
--- a/portal/frontend/src/chart/paneViews/factory.js
+++ b/portal/frontend/src/chart/paneViews/factory.js
@@ -27,7 +27,7 @@ export class PaneViewManager {
     if (this.series.has(type)) return;
     let view;
     if (type === PaneViewType.TOUCH)      view = createTouchPaneView(this.ts);
-    else if (type === PaneViewType.VA_BOX)  view = createVABoxPaneView(this.ts, { extendRight: true, hatchOverlap: false, outlineFront: true });
+    else if (type === PaneViewType.VA_BOX)  view = createVABoxPaneView(this.ts, { hatchOverlap: false, outlineFront: true });
     else if (type === PaneViewType.SEGMENT) view = createSegmentPaneView(this.ts);
     else if (type === PaneViewType.POLYLINE) view = createPolylinePaneView(this.ts);
     else if (type === PaneViewType.SIGNAL_BUBBLE) view = createSignalBubblePaneView(this.ts);
@@ -98,54 +98,17 @@ export class PaneViewManager {
     if (!view || !series) return;
 
     const boxes = this.vaBoxState.boxes || [];
-    const { lastSeriesTime, barSpacing } = this.vaBoxState;
+    const { lastSeriesTime } = this.vaBoxState;
 
     view.setBoxes(boxes);
 
     const normalizedLast = toSec(lastSeriesTime);
 
-    const rawTimes = [...new Set(boxes.flatMap(b => [toSec(b.x1), toSec(b.x2)]))]
-      .filter(Number.isFinite)
-      .sort((a,b)=>a-b);
-
-    let smallestStep = Infinity;
-    for (let i = 1; i < rawTimes.length; i++) {
-      const step = rawTimes[i] - rawTimes[i - 1];
-      if (step > 0 && step < smallestStep) smallestStep = step;
-    }
-
-    const fallbackStep = 60; // 1 minute padding if we cannot infer spacing
-    const extensionStep = Number.isFinite(smallestStep) && smallestStep > 0 ? smallestStep : fallbackStep;
-    const inferredSpacing = Number.isFinite(barSpacing) && barSpacing > 0 ? barSpacing : extensionStep;
-
-    const rightEdge = Math.max(
-      ...boxes
-        .map(b => toSec(b.x2))
-        .filter((t) => typeof t === 'number' && Number.isFinite(t)),
-      -Infinity,
-    );
-
-    const baseEdge = Number.isFinite(normalizedLast)
-      ? normalizedLast
-      : (Number.isFinite(rightEdge) ? rightEdge : null);
-
-    const paddedRightEdge = Number.isFinite(baseEdge)
-      ? baseEdge + (Number.isFinite(inferredSpacing) ? inferredSpacing : 0)
-      : null;
-
-    const seriesTimes = [...new Set([
-      ...rawTimes,
-      Number.isFinite(normalizedLast) ? normalizedLast : null,
-      Number.isFinite(paddedRightEdge) ? paddedRightEdge : null,
-    ].filter(Number.isFinite))].sort((a, b) => a - b);
+    const seriesTimes = [...new Set(boxes.flatMap(b => [toSec(b.x1), toSec(b.x2), normalizedLast]))]
+      .filter((t) => typeof t === 'number' && Number.isFinite(t))
+      .sort((a, b) => a - b);
 
     series.setData(seriesTimes.map(t => ({ time: t, originalData: {} })));
-
-    view.setRightEdgeTime(
-      Number.isFinite(paddedRightEdge)
-        ? paddedRightEdge
-        : (Number.isFinite(baseEdge) ? baseEdge : null)
-    );
   }
   setSegments(segs){ this.ensure(PaneViewType.SEGMENT);
     this.views.get(PaneViewType.SEGMENT).setSegments(segs || []);

--- a/portal/frontend/src/chart/paneViews/vaBoxPaneView.js
+++ b/portal/frontend/src/chart/paneViews/vaBoxPaneView.js
@@ -1,12 +1,9 @@
 export function createVABoxPaneView(timeScaleApi, opts = {}) {
   const {
     hatchOverlap = true,
-    extendRight = true,
     outlineFront = false,
-    rightEdgeMode = 'last-bar',        // 'pane' | 'last-bar'
-  } = opts;  
+  } = opts;
   let boxes = []; // [{ x1, x2, y1, y2, color, border? }]
-  let rightEdgeTimeSec = null;     // set from outside when you know last candle time
 
   const toSec = t => (typeof t === 'number' && t > 2e10 ? Math.floor(t / 1000) : t);
   const withAlpha = (rgba, a) =>
@@ -21,15 +18,8 @@ export function createVABoxPaneView(timeScaleApi, opts = {}) {
       const xLeft = leftCoord != null ? leftCoord * hpr : null;
       let xRight;
       const hasExplicitRight = b?.x2 != null;
-      if (!extendRight || hasExplicitRight) {
-        const rightCoord = timeScaleApi.timeToCoordinate(toSec(hasExplicitRight ? b.x2 : b.x1));
-        xRight = rightCoord != null ? rightCoord * hpr : null;
-      } else if (rightEdgeMode === 'last-bar' && rightEdgeTimeSec != null) {
-        const rightCoord = timeScaleApi.timeToCoordinate(rightEdgeTimeSec);
-        xRight = rightCoord != null ? rightCoord * hpr : null;
-      } else {
-        xRight = mediaWidth; // pane edge
-      }
+      const rightCoord = timeScaleApi.timeToCoordinate(toSec(hasExplicitRight ? b.x2 : b.x1));
+      xRight = rightCoord != null ? rightCoord * hpr : null;
       if (xLeft == null || xRight == null) continue;
 
       const y1 = priceToCoordinate(b.y1) * vpr;
@@ -113,6 +103,5 @@ export function createVABoxPaneView(timeScaleApi, opts = {}) {
     defaultOptions() { return { priceLineVisible: false, lastValueVisible: false, crosshairMarkerVisible: false }; },
     destroy: () => {},
     setBoxes(arr) { boxes = Array.isArray(arr) ? arr : []; },
-    setRightEdgeTime(sec) { rightEdgeTimeSec = Number.isFinite(sec) ? sec : null; },
   };
 }

--- a/portal/frontend/src/components/IndicatorCard.jsx
+++ b/portal/frontend/src/components/IndicatorCard.jsx
@@ -36,8 +36,6 @@ export default function IndicatorCard({
   onDelete,
   onGenerateSignals,
   onSelectColor,
-  marketProfileConfig = null,
-  onUpdateMarketProfileConfig,
   isGeneratingSignals = false,
   disableSignalAction = false,
 }) {
@@ -93,35 +91,6 @@ export default function IndicatorCard({
       .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
       .join(" ");
   }, [indicator?.type]);
-
-  const mpConfig = useMemo(() => ({
-    useMerged: marketProfileConfig?.useMerged ?? true,
-    mergeThreshold: marketProfileConfig?.mergeThreshold ?? 0.6,
-  }), [marketProfileConfig?.useMerged, marketProfileConfig?.mergeThreshold]);
-
-  const clampedThreshold = (() => {
-    const raw = Number.isFinite(mpConfig.mergeThreshold) ? mpConfig.mergeThreshold : 0.6;
-    return Math.min(Math.max(raw, 0), 1);
-  })();
-
-  const mergePct = Math.round(clampedThreshold * 100);
-
-  const handleToggleMerged = (next) => {
-    if (typeof onUpdateMarketProfileConfig !== "function") return;
-    const payload = { useMerged: next };
-    if (next && marketProfileConfig?.mergeThreshold == null) {
-      payload.mergeThreshold = 0.6;
-    }
-    onUpdateMarketProfileConfig(payload);
-  };
-
-  const handleThresholdChange = (event) => {
-    if (typeof onUpdateMarketProfileConfig !== "function") return;
-    const raw = Number(event?.target?.value);
-    if (Number.isNaN(raw)) return;
-    const clamped = Math.min(Math.max(raw, 0), 100);
-    onUpdateMarketProfileConfig({ mergeThreshold: clamped / 100 });
-  };
 
   return (
     <div className="flex items-start justify-between gap-4 rounded-2xl border border-white/10 bg-[#1f2230]/80 p-4 shadow-[0_20px_60px_-40px_rgba(0,0,0,0.85)]">
@@ -251,51 +220,6 @@ export default function IndicatorCard({
                         ))}
                       </div>
                   </div>
-
-                  {indicator?.type === "market_profile" && (
-                    <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-emerald-100">
-                      <div className="flex items-center justify-between gap-3">
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-200">
-                            Market profile signals
-                          </p>
-                          <p className="text-[11px] text-emerald-100/80">
-                            Control merged value areas used for signal payloads.
-                          </p>
-                        </div>
-                        <Switch
-                          checked={!!mpConfig.useMerged}
-                          onChange={handleToggleMerged}
-                          className={`${mpConfig.useMerged ? "bg-emerald-400/80" : "bg-emerald-900/50"} relative inline-flex h-6 w-11 items-center rounded-full transition`}
-                        >
-                          <span className={`${mpConfig.useMerged ? "translate-x-6" : "translate-x-1"} inline-block h-4 w-4 transform rounded-full bg-white transition`} />
-                        </Switch>
-                      </div>
-
-                      <div className="mt-4 space-y-2">
-                        <label className="flex items-center justify-between text-[11px] uppercase tracking-[0.18em] text-emerald-200/80">
-                          Overlap requirement
-                          <span className="rounded-full border border-emerald-400/40 px-2 py-0.5 text-[10px] font-semibold text-emerald-100/90">
-                            {mergePct}%
-                          </span>
-                        </label>
-                        <input
-                          type="range"
-                          min="0"
-                          max="100"
-                          step="5"
-                          value={mergePct}
-                          onChange={handleThresholdChange}
-                          disabled={!mpConfig.useMerged}
-                          className="w-full accent-emerald-300 disabled:opacity-40"
-                          aria-label="Merged profile overlap percentage"
-                        />
-                        <p className="text-[11px] text-emerald-100/70">
-                          Higher percentages require more shared value-area depth before sessions merge.
-                        </p>
-                      </div>
-                    </div>
-                  )}
 
                   <div className="grid gap-2 text-xs">
                     <button

--- a/portal/frontend/src/components/IndicatorTab.jsx
+++ b/portal/frontend/src/components/IndicatorTab.jsx
@@ -105,8 +105,6 @@ export const IndicatorSection = ({ chartId }) => {
 
   // Read current chart slice
   const chartState = getChart(chartId)
-  const marketProfileSignals = chartState?.signalsConfig?.marketProfile || {}
-
   useEffect(() => {
     if (!Array.isArray(indicators)) {
       setIndColors((prev) => (Object.keys(prev).length ? {} : prev));
@@ -372,18 +370,6 @@ export const IndicatorSection = ({ chartId }) => {
           changed = true
         }
 
-        const mpConfig = currentConfig.marketProfile
-        if (mpConfig && Object.prototype.hasOwnProperty.call(mpConfig, id)) {
-          const nextMarketProfile = { ...mpConfig }
-          delete nextMarketProfile[id]
-          if (Object.keys(nextMarketProfile).length > 0) {
-            nextConfig.marketProfile = nextMarketProfile
-          } else {
-            delete nextConfig.marketProfile
-          }
-          changed = true
-        }
-
         if (changed) {
           const remainingKeys = Object.keys(nextConfig)
           updateChart(chartId, {
@@ -405,41 +391,6 @@ export const IndicatorSection = ({ chartId }) => {
       return next;
     });
   };
-
-  const updateMarketProfileSignalsConfig = (indicatorId, patch = {}) => {
-    if (!indicatorId || typeof patch !== 'object') return;
-    const currentChart = getChart(chartId) || {};
-    const currentConfig = currentChart?.signalsConfig || {};
-    const currentMarketProfile = currentConfig?.marketProfile || {};
-    const existing = currentMarketProfile[indicatorId] || {};
-    const nextEntry = { ...existing, ...patch };
-
-    const cleaned = Object.fromEntries(
-      Object.entries(nextEntry).filter(([, value]) => value !== undefined && value !== null && !Number.isNaN(value)),
-    );
-
-    if (shallowEqualMap(existing, cleaned)) {
-      return;
-    }
-
-    const nextMarketProfile = { ...currentMarketProfile };
-    if (Object.keys(cleaned).length === 0) {
-      delete nextMarketProfile[indicatorId];
-    } else {
-      nextMarketProfile[indicatorId] = cleaned;
-    }
-
-    const nextSignalsConfig = { ...currentConfig };
-    if (Object.keys(nextMarketProfile).length === 0) {
-      delete nextSignalsConfig.marketProfile;
-    } else {
-      nextSignalsConfig.marketProfile = nextMarketProfile;
-    }
-
-    const nextKeys = Object.keys(nextSignalsConfig);
-    updateChart(chartId, { signalsConfig: nextKeys.length ? nextSignalsConfig : null });
-  };
-
 
   // Regenerate signals (not yet implemented)
   const generateSignals = async (id) => {
@@ -730,8 +681,6 @@ export const IndicatorSection = ({ chartId }) => {
                   onGenerateSignals={generateSignals}
                   onSelectColor={handleSelectColor}
                   colorSwatches={COLOR_SWATCHES}
-                  marketProfileConfig={marketProfileSignals[indicator.id] || null}
-                  onUpdateMarketProfileConfig={(patch) => updateMarketProfileSignalsConfig(indicator.id, patch)}
                   isGeneratingSignals={isGenerating}
                   disableSignalAction={disableSignals}
                 />

--- a/portal/frontend/src/components/indicatorSignals.js
+++ b/portal/frontend/src/components/indicatorSignals.js
@@ -114,20 +114,6 @@ export async function runSignalGeneration({
       config.enabled_rules = enabledRules;
     }
 
-    const marketProfileConfig = chartState?.signalsConfig?.marketProfile?.[indicator.id];
-    if (marketProfileConfig && typeof marketProfileConfig === 'object') {
-      if (marketProfileConfig.useMerged !== undefined) {
-        config.market_profile_use_merged_value_areas = Boolean(marketProfileConfig.useMerged);
-      }
-      if (marketProfileConfig.mergeThreshold !== undefined && marketProfileConfig.mergeThreshold !== null) {
-        const threshold = Number(marketProfileConfig.mergeThreshold);
-        if (Number.isFinite(threshold)) {
-          const clamped = Math.min(Math.max(threshold, 0), 1);
-          config.market_profile_merge_threshold = clamped;
-        }
-      }
-    }
-
     scopedLogger.debug('signal_generation_request', { config });
 
     const response = await signalsAdapter(indicator.id, {

--- a/src/signals/rules/market_profile.py
+++ b/src/signals/rules/market_profile.py
@@ -322,12 +322,17 @@ def _value_area_breakout_evaluator(context: Mapping[str, Any], value_area: Mappi
             if start_ts is not None and trigger_ts < start_ts:
                 continue
 
+            if end_ts is not None and trigger_ts > end_ts:
+                continue
+
             if min_allowed_ts is not None and trigger_ts < min_allowed_ts:
                 continue
 
             breakout_start_ts = _normalise_meta_timestamp(meta.get("breakout_start"), tz)
             if breakout_start_ts is not None:
                 if start_ts is not None and breakout_start_ts < start_ts:
+                    continue
+                if end_ts is not None and breakout_start_ts > end_ts:
                     continue
                 if min_allowed_ts is not None and breakout_start_ts < min_allowed_ts:
                     continue
@@ -379,6 +384,9 @@ def _value_area_breakout_evaluator(context: Mapping[str, Any], value_area: Mappi
                 enriched["symbol"] = symbol
 
             trigger_idx = _resolve_breakout_bar_index(enriched, df)
+            if trigger_idx is not None:
+                if end_index is not None and trigger_idx > end_index:
+                    continue
             if trigger_idx is not None and trigger_idx > 0:
                 try:
                     enriched["prev_close"] = float(df.iloc[trigger_idx - 1]["close"])

--- a/tests/test_signals/test_market_profile_rules.py
+++ b/tests/test_signals/test_market_profile_rules.py
@@ -202,6 +202,33 @@ def test_breakout_evaluator_respects_indicator_extend_flag(sample_market_profile
         assert meta["value_area_end_index"] == expected_index
 
 
+def test_breakout_evaluator_ignores_triggers_past_value_area_end(sample_market_profile_df):
+    indicator = MarketProfileIndicator(
+        sample_market_profile_df,
+        extend_value_area_to_chart_end=False,
+    )
+    context = {
+        "indicator": indicator,
+        "df": sample_market_profile_df,
+        "symbol": "TEST",
+        "mode": "backtest",
+        "market_profile_breakout_min_age_hours": 0,
+    }
+
+    truncated_end = sample_market_profile_df.index[1]
+    value_area = {
+        "start": sample_market_profile_df.index[0],
+        "end": truncated_end,
+        "VAH": 102.0,
+        "VAL": 98.0,
+        "POC": 100.0,
+    }
+
+    metas = _value_area_breakout_evaluator(context, value_area)
+
+    assert metas == []
+
+
 def test_breakout_evaluator_live_mode_only_reports_latest(sample_value_area):
     index = pd.date_range("2025-01-02 09:30", periods=3, freq="15min", tz="UTC")
     data = {


### PR DESCRIPTION
## Summary
- drop market profile breakout metadata that lands after the value area end and guard the resolved trigger index
- add coverage for ignored breakouts when the session end precedes trigger timestamps
- simplify the UI by removing market profile merge controls and rely on backend-provided box bounds

## Testing
- pytest tests/test_signals/test_market_profile_rules.py *(skipped: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dde71d610c83318b91cfdfa8e11e2b