### PR TITLE
Refine market profile logging summaries

### DIFF
--- a/src/signals/engine/market_profile_generator.py
+++ b/src/signals/engine/market_profile_generator.py
@@ -1,6 +1,7 @@
 from typing import List, Dict, Optional, Sequence, Mapping, Any, Tuple
 import logging
 import math
+from time import perf_counter
 
 import pandas as pd
 from indicators.market_profile import MarketProfileIndicator
@@ -17,6 +18,14 @@ from signals.rules.market_profile import (
 )
 
 logger = logging.getLogger("MarketProfileSignalGenerator")
+
+
+def _format_duration(seconds: float) -> str:
+    """Return a compact, human readable duration string."""
+
+    if seconds >= 1:
+        return f"{seconds:.2f}s"
+    return f"{seconds * 1000:.1f}ms"
 
 
 def _finite_float(value: Any) -> Optional[float]:
@@ -80,8 +89,22 @@ def build_value_area_payloads(
 ) -> List[Dict[str, Any]]:
     """Derive value area payloads for market profile signal rules."""
 
+    symbol = getattr(indicator, "symbol", None)
+
+    if df is None or df.empty:
+        logger.info(
+            "Market profile payloads skipped | symbol=%s | reason=empty-data",
+            symbol,
+        )
+        return []
+
+    start_time = perf_counter()
     runtime = _clone_indicator_for_runtime(indicator, df, interval=interval)
     if runtime is None:
+        logger.info(
+            "Market profile payloads skipped | symbol=%s | reason=indicator-init",
+            symbol,
+        )
         return []
 
     if use_merged is None:
@@ -101,9 +124,31 @@ def build_value_area_payloads(
         value_areas = runtime.daily_profiles
 
     payloads: List[Dict[str, Any]] = []
-    for area in value_areas or []:
+    profile_labels: List[str] = []
+    for idx, area in enumerate(value_areas or []):
         if isinstance(area, Mapping) and area.get("VAH") is not None and area.get("VAL") is not None:
-            payloads.append(dict(area))
+            payload = dict(area)
+            payloads.append(payload)
+            label = _value_area_reference(payload, idx)
+            profile_labels.append(label)
+
+    elapsed = perf_counter() - start_time
+    if profile_labels:
+        preview = ", ".join(profile_labels[:5])
+        if len(profile_labels) > 5:
+            preview = f"{preview}, …"
+        session_summary = f" | sessions={preview}"
+    else:
+        session_summary = ""
+
+    logger.info(
+        "Market profile payloads ready | symbol=%s | profiles=%d | merged=%s | duration=%s%s",
+        symbol,
+        len(payloads),
+        use_merged,
+        _format_duration(elapsed),
+        session_summary,
+    )
 
     return payloads
 
@@ -123,10 +168,15 @@ class MarketProfileSignalGenerator:
         if self.symbol is None:
             raise ValueError("MarketProfileSignalGenerator requires a symbol for rule execution")
 
-        payloads = (
-            list(value_areas)
-            if value_areas is not None
-            else build_value_area_payloads(
+        start_time = perf_counter()
+
+        if value_areas is not None:
+            payloads = list(value_areas)
+            payload_source = "provided"
+            payload_duration = 0.0
+        else:
+            payload_start = perf_counter()
+            payloads = build_value_area_payloads(
                 self.indicator,
                 df,
                 interval=getattr(self.indicator, "interval", None),
@@ -134,14 +184,33 @@ class MarketProfileSignalGenerator:
                 merge_threshold=config.get("market_profile_merge_threshold"),
                 min_merge_sessions=config.get("market_profile_merge_min_sessions"),
             )
-        )
-        return run_indicator_rules(
+            payload_duration = perf_counter() - payload_start
+            payload_source = "computed"
+
+        rules_start = perf_counter()
+        signals = run_indicator_rules(
             self.indicator,
             df,
             rule_payloads=payloads,
             symbol=self.symbol,
             **config,
         )
+        rules_duration = perf_counter() - rules_start
+        total_duration = perf_counter() - start_time
+
+        logger.info(
+            "Market profile signals | symbol=%s | profiles=%d | signals=%d | payload_source=%s | "
+            "durations[payloads=%s, rules=%s, total=%s]",
+            self.symbol,
+            len(payloads),
+            len(signals),
+            payload_source,
+            "n/a" if payload_source == "provided" else _format_duration(payload_duration),
+            _format_duration(rules_duration),
+            _format_duration(total_duration),
+        )
+
+        return signals
 
     @staticmethod
     def to_overlays(
@@ -348,28 +417,54 @@ def _confidence_meta(metadata: Mapping[str, Any]) -> Optional[str]:
     return f"Confidence {percent}%"
 
 
+def _value_area_reference(area: Mapping[str, Any], index: int) -> str:
+    """Return a human-readable label for a value area payload."""
+
+    for key in (
+        "session_label",
+        "session",
+        "session_start",
+        "profile_start",
+        "date",
+        "value_area_id",
+    ):
+        value = area.get(key)
+        if value not in (None, ""):
+            return str(value)
+
+    return f"profile-{index + 1}"
+
+
 def _market_profile_overlay_adapter(
     signals: List[BaseSignal],
     plot_df: pd.DataFrame,
     **_: Any,
 ) -> List[Dict[str, Any]]:
-    logger.info("Converting %d signals to bubble overlays", len(signals))
+    start_time = perf_counter()
     bubbles: List[Dict[str, Any]] = []
+    summary = {
+        "total": len(signals),
+        "converted_breakout": 0,
+        "converted_retest": 0,
+        "skipped_source": 0,
+        "skipped_price": 0,
+        "skipped_time": 0,
+    }
 
     for idx, sig in enumerate(signals):
         metadata = sig.metadata or {}
         if metadata.get("source") != "MarketProfile":
-            logger.debug("Skipping signal %d: not from MarketProfile source", idx)
+            summary["skipped_source"] += 1
             continue
 
         level_price = _resolve_level_price(metadata)
         if level_price is None:
-            logger.debug("Skipping signal %d: unresolved level price", idx)
+            summary["skipped_price"] += 1
             continue
 
         marker_time = _to_epoch_seconds(sig.time)
         if marker_time is None:
-            logger.debug("Skipping signal %d: invalid signal time %s", idx, sig.time)
+            summary["skipped_time"] += 1
             continue
 
         level_label = _level_label(metadata)
@@ -403,13 +498,7 @@ def _market_profile_overlay_adapter(
                     "subtype": "bubble",
                 }
             )
-            logger.debug(
-                "Signal %d converted to retest bubble | level=%s | price=%.2f | direction=%s",
-                idx,
-                level_label,
-                float(anchor_price),
-                direction,
-            )
+            summary["converted_retest"] += 1
             continue
 
         breakout_direction = str(metadata.get("breakout_direction", "")).lower()
@@ -462,19 +551,27 @@ def _market_profile_overlay_adapter(
                 "subtype": "bubble",
             }
         )
-        logger.debug(
-            "Signal %d converted to breakout bubble | level=%s | price=%.2f | direction=%s",
-            idx,
-            level_label,
-            bubble_price,
-            breakout_direction,
-        )
+        summary["converted_breakout"] += 1
+
+    duration = perf_counter() - start_time
+    symbol = next((sig.symbol for sig in signals if getattr(sig, "symbol", None)), None)
+
+    logger.info(
+        "Market profile overlays | symbol=%s | total=%d | converted=%d (breakout=%d, retest=%d) | "
+        "skipped[source=%d, price=%d, time=%d] | duration=%s",
+        symbol,
+        summary["total"],
+        len(bubbles),
+        summary["converted_breakout"],
+        summary["converted_retest"],
+        summary["skipped_source"],
+        summary["skipped_price"],
+        summary["skipped_time"],
+        _format_duration(duration),
+    )
 
     if not bubbles:
-        logger.info("Converted 0 signals to overlays")
         return []
-
-    logger.info("Converted %d signals to overlays", len(bubbles))
     payload = {
         "price_lines": [],
         "markers": [],


### PR DESCRIPTION
## Summary
- add reusable duration formatting and session labelling helpers to support concise market profile logging
- report aggregated timings and payload details when computing market profile signals
- collapse overlay adapter debug noise into a single high-level summary with skip/convert counts

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68ddedea2e58833196ca1c4309f57300