### PR TITLE
Align default Market Profile merge session count

### DIFF
--- a/src/indicators/market_profile.py
+++ b/src/indicators/market_profile.py
@@ -50,6 +50,7 @@ class MarketProfileIndicator(BaseIndicator):
     Value Area High (VAH), and Value Area Low (VAL), and provides plotting overlays.
     """
     NAME = "market_profile"
+    DEFAULT_MIN_MERGE_SESSIONS = 3
 
     def __init__(
         self,
@@ -60,6 +61,7 @@ class MarketProfileIndicator(BaseIndicator):
         extend_value_area_to_chart_end: bool = True,
         use_merged_value_areas: bool = True,
         merge_threshold: float = 0.6,
+        min_merge_sessions: int = DEFAULT_MIN_MERGE_SESSIONS,
     ):
         super().__init__(df)
         self.bin_size = bin_size
@@ -71,6 +73,7 @@ class MarketProfileIndicator(BaseIndicator):
         self.extend_value_area_to_chart_end = bool(extend_value_area_to_chart_end)
         self.use_merged_value_areas = bool(use_merged_value_areas)
         self.merge_threshold = float(merge_threshold) if merge_threshold is not None else 0.6
+        self.min_merge_sessions = int(min_merge_sessions)
 
     @staticmethod
     def describe_profile(profile: Mapping[str, Any]) -> str:
@@ -130,6 +133,7 @@ class MarketProfileIndicator(BaseIndicator):
         extend_value_area_to_chart_end: bool = True,
         use_merged_value_areas: bool = True,
         merge_threshold: float = 0.6,
+        min_merge_sessions: int = DEFAULT_MIN_MERGE_SESSIONS,
     ):
         """
         Fetches OHLCV from provider and constructs the indicator.
@@ -150,6 +154,7 @@ class MarketProfileIndicator(BaseIndicator):
             extend_value_area_to_chart_end=extend_value_area_to_chart_end,
             use_merged_value_areas=use_merged_value_areas,
             merge_threshold=merge_threshold,
+            min_merge_sessions=min_merge_sessions,
         )
 
     def _compute_daily_profiles(self) -> List[Dict[str, float]]:
@@ -228,7 +233,7 @@ class MarketProfileIndicator(BaseIndicator):
     def merge_value_areas(
         self,
         threshold: Optional[float] = None,
-        min_merge: int = 2,
+        min_merge: Optional[int] = None,
     ) -> List[Dict[str, float]]:
         """
         Combine consecutive daily profiles whose value areas overlap
@@ -237,6 +242,15 @@ class MarketProfileIndicator(BaseIndicator):
         if threshold is None:
             threshold = getattr(self, "merge_threshold", 0.6)
         threshold = float(threshold)
+
+        if min_merge is None:
+            min_merge = getattr(
+                self,
+                "min_merge_sessions",
+                getattr(self, "DEFAULT_MIN_MERGE_SESSIONS", 3),
+            )
+        else:
+            min_merge = int(min_merge)
 
         merged = []
         profiles = self.daily_profiles
@@ -404,7 +418,7 @@ class MarketProfileIndicator(BaseIndicator):
         plot_df: pd.DataFrame,
         use_merged: Optional[bool] = None,
         merge_threshold: Optional[float] = None,
-        min_merge: int = 3,
+        min_merge: Optional[int] = None,
         include_touches: bool = True,
         time_fmt="business_day",
         extend_boxes_to_chart_end: Optional[bool] = None,
@@ -443,7 +457,16 @@ class MarketProfileIndicator(BaseIndicator):
         if use_merged:
             # compute merged profiles once if needed
             if not getattr(self, "merged_profiles", None):
-                self.merge_value_areas(threshold=merge_threshold, min_merge=min_merge)
+                default_min_merge = getattr(
+                    self,
+                    "min_merge_sessions",
+                    getattr(self, "DEFAULT_MIN_MERGE_SESSIONS", 3),
+                )
+                effective_min_merge = default_min_merge if min_merge is None else int(min_merge)
+                self.merge_value_areas(
+                    threshold=merge_threshold,
+                    min_merge=effective_min_merge,
+                )
             profiles = self.merged_profiles or []
         else:
             profiles = self.daily_profiles or []

--- a/src/signals/engine/market_profile_generator.py
+++ b/src/signals/engine/market_profile_generator.py
@@ -70,6 +70,11 @@ def _clone_indicator_for_runtime(
                 True,
             ),
             merge_threshold=getattr(indicator, "merge_threshold", 0.6),
+            min_merge_sessions=getattr(
+                indicator,
+                "min_merge_sessions",
+                getattr(MarketProfileIndicator, "DEFAULT_MIN_MERGE_SESSIONS", 3),
+            ),
         )
     except Exception:
         logger.exception("Failed to initialise MarketProfileIndicator for signal payloads")
@@ -118,7 +123,12 @@ def build_value_area_payloads(
             if merge_threshold is None
             else float(merge_threshold)
         )
-        min_merge = 2 if min_merge_sessions is None else int(min_merge_sessions)
+        default_min_merge = getattr(
+            runtime,
+            "min_merge_sessions",
+            getattr(MarketProfileIndicator, "DEFAULT_MIN_MERGE_SESSIONS", 3),
+        )
+        min_merge = default_min_merge if min_merge_sessions is None else int(min_merge_sessions)
         value_areas = runtime.merge_value_areas(threshold=threshold, min_merge=min_merge)
     else:
         value_areas = runtime.daily_profiles

--- a/tests/test_indicators/test_market_profile_indicator.py
+++ b/tests/test_indicators/test_market_profile_indicator.py
@@ -44,7 +44,7 @@ def test_market_profile_indicator_integration_plot():
     assert isinstance(mpi.daily_profiles, list)
     assert mpi.daily_profiles, "Integration: daily_profiles is empty"
 
-    # Merge value areas (default threshold=0.6, min_merge=2)
+    # Merge value areas (default threshold=0.6, min_merge=3)
     merged = mpi.merge_value_areas()
     # merged_profiles may be empty if no consecutive overlaps exist, but daily_profiles must exist
     assert isinstance(merged, list)

--- a/tests/test_signals/test_market_profile_overlay_adapter.py
+++ b/tests/test_signals/test_market_profile_overlay_adapter.py
@@ -4,8 +4,10 @@ pd = pytest.importorskip("pandas")
 
 from datetime import datetime
 
+from indicators.market_profile import MarketProfileIndicator
 from signals.base import BaseSignal
 from signals.engine.signal_generator import build_signal_overlays
+from signals.engine.market_profile_generator import build_value_area_payloads
 from signals.engine import market_profile_generator  # noqa: F401 ensure adapter registration
 
 
@@ -93,3 +95,25 @@ def test_market_profile_signals_render_as_bubbles():
     assert retest_bubble["direction"] == "down"
     assert retest_bubble["accentColor"] == "#f97316"
     assert retest_bubble["detail"].startswith("Retest after 3 bars")
+
+
+def test_default_min_merge_consistency_between_overlay_and_signal(monkeypatch):
+    df = _make_df()
+    indicator = MarketProfileIndicator(df)
+
+    captured_min_merge = []
+
+    def _capture_merge(self, threshold=None, min_merge=None):
+        captured_min_merge.append(min_merge)
+        return []
+
+    monkeypatch.setattr(MarketProfileIndicator, "merge_value_areas", _capture_merge)
+
+    indicator.to_lightweight(df, use_merged=True)
+    build_value_area_payloads(indicator, df)
+
+    assert captured_min_merge, "Expected merge_value_areas to be invoked"
+    assert all(
+        value == MarketProfileIndicator.DEFAULT_MIN_MERGE_SESSIONS
+        for value in captured_min_merge
+    ), "Default min-merge sessions should match for overlays and signals"


### PR DESCRIPTION
## Summary
- centralize the MarketProfileIndicator minimum merge sessions default and expose it via the constructor/from_context helpers
- ensure runtime cloning and signal payload generation reuse the indicator min-merge default when none is provided
- add a regression test confirming overlay and signal code paths share the same merged-session default

## Testing
- pytest tests/test_signals/test_market_profile_overlay_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68de00111a10833187cfba2797424224