### PR TITLE
Cache breakout signals for retest generation

### DIFF
--- a/portal/backend/service/indicator_service.py
+++ b/portal/backend/service/indicator_service.py
@@ -1,11 +1,16 @@
 # service/indicator_service.py
 from __future__ import annotations
 
-import uuid
 import inspect
 import logging
-from typing import Any, Dict, List, Optional, Tuple
 import math
+import uuid
+from collections.abc import Mapping, MutableMapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+
 import numpy as np
 import pandas as pd
 
@@ -20,9 +25,17 @@ from signals.engine.signal_generator import (
     describe_indicator_rules,
     run_indicator_rules,
 )
-from signals.engine import pivot_level_generator  # noqa: F401
+from signals.base import BaseSignal
 from signals.engine import market_profile_generator  # noqa: F401
+from signals.engine import pivot_level_generator  # noqa: F401
 from signals.engine.market_profile_generator import build_value_area_payloads
+from signals.rules.market_profile import (
+    MarketProfileBreakoutConfig,
+    _BREAKOUT_CACHE_INITIALISED,
+    _BREAKOUT_CACHE_KEY,
+    _BREAKOUT_READY_FLAG,
+)
+from signals.rules.pivot import PivotBreakoutConfig, _PIVOT_BREAKOUT_READY_FLAG
 
 pivot_level_generator.ensure_registration()
 
@@ -39,6 +52,188 @@ _INDICATOR_MAP = {
 # Ensure default signal rules are registered for built-in indicators
 # In-memory registry: id -> {"meta": <pydantic-like dict>, "instance": <object>}
 _REGISTRY: Dict[str, Dict[str, Any]] = {}
+
+
+@dataclass(frozen=True)
+class BreakoutCacheSpec:
+    breakout_rule_id: str
+    retest_rule_id: str
+    cache_context_key: str
+    ready_flag_key: str
+    initialised_flag_key: Optional[str]
+    config_signature_builder: Callable[[Mapping[str, Any]], Tuple[Any, ...]]
+    rule_signal_types: Dict[str, Set[str]] = field(default_factory=dict)
+    context_defaults: Mapping[str, Any] = field(default_factory=dict)
+
+
+_PIVOT_BREAKOUT_CACHE_KEY = "pivot_breakouts"
+
+
+_DEFAULT_PIVOT_BREAKOUT_CONFIG = PivotBreakoutConfig()
+_DEFAULT_MARKET_PROFILE_BREAKOUT_CONFIG = MarketProfileBreakoutConfig()
+
+
+_BREAKOUT_CACHE_SPECS: Dict[str, BreakoutCacheSpec] = {}
+
+
+_BREAKOUT_SIGNAL_CACHE: Dict[Tuple[Any, ...], List[Dict[str, Any]]] = {}
+
+
+def _purge_breakout_cache(inst_id: str) -> None:
+    if not inst_id:
+        return
+    stale_keys = [key for key in _BREAKOUT_SIGNAL_CACHE if key and key[0] == inst_id]
+    for cache_key in stale_keys:
+        _BREAKOUT_SIGNAL_CACHE.pop(cache_key, None)
+
+
+def _hashable_signature(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if hasattr(value, "isoformat"):
+        try:
+            return value.isoformat()
+        except Exception:
+            pass
+    if isinstance(value, Mapping):
+        return tuple(sorted((k, _hashable_signature(v)) for k, v in value.items()))
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(_hashable_signature(v) for v in value)
+    return str(value)
+
+
+def _coerce_int(value: Any, default: int, *, minimum: Optional[int] = None) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return default
+    if minimum is not None and result < minimum:
+        return default
+    return result
+
+
+def _coerce_float(value: Any, default: float, *, minimum: Optional[float] = None) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return default
+    if math.isnan(result) or math.isinf(result):
+        return default
+    if minimum is not None and result < minimum:
+        return default
+    return result
+
+
+def _pivot_breakout_signature(config: Mapping[str, Any]) -> Tuple[Any, ...]:
+    cfg = config.get("pivot_breakout_config")
+    if isinstance(cfg, PivotBreakoutConfig):
+        confirmation = cfg.confirmation_bars
+        early_window = cfg.early_confirmation_window
+        early_pct = cfg.early_confirmation_distance_pct
+    else:
+        confirmation = _coerce_int(
+            config.get("pivot_breakout_confirmation_bars"),
+            _DEFAULT_PIVOT_BREAKOUT_CONFIG.confirmation_bars,
+            minimum=1,
+        )
+        early_window = _coerce_int(
+            config.get("pivot_breakout_early_window"),
+            _DEFAULT_PIVOT_BREAKOUT_CONFIG.early_confirmation_window,
+            minimum=1,
+        )
+        early_pct = _coerce_float(
+            config.get("pivot_breakout_early_distance_pct"),
+            _DEFAULT_PIVOT_BREAKOUT_CONFIG.early_confirmation_distance_pct,
+            minimum=0.0,
+        )
+    mode = str(config.get("mode", "backtest")).lower()
+    return (mode, confirmation, early_window, float(early_pct))
+
+
+def _market_profile_breakout_signature(config: Mapping[str, Any]) -> Tuple[Any, ...]:
+    cfg = config.get("market_profile_breakout_config")
+    if isinstance(cfg, MarketProfileBreakoutConfig):
+        confirmation = cfg.confirmation_bars
+        early_window = cfg.early_confirmation_window
+        early_pct = cfg.early_confirmation_distance_pct
+    else:
+        confirmation = _coerce_int(
+            config.get("market_profile_breakout_confirmation_bars"),
+            _DEFAULT_MARKET_PROFILE_BREAKOUT_CONFIG.confirmation_bars,
+            minimum=1,
+        )
+        early_window = _coerce_int(
+            config.get("market_profile_breakout_early_window"),
+            _DEFAULT_MARKET_PROFILE_BREAKOUT_CONFIG.early_confirmation_window,
+            minimum=1,
+        )
+        early_pct = _coerce_float(
+            config.get("market_profile_breakout_early_distance_pct"),
+            _DEFAULT_MARKET_PROFILE_BREAKOUT_CONFIG.early_confirmation_distance_pct,
+            minimum=0.0,
+        )
+    mode = str(config.get("mode", "backtest")).lower()
+    payload_sig = _hashable_signature(config.get("rule_payloads"))
+    return (mode, confirmation, early_window, float(early_pct), payload_sig)
+
+
+def _clone_breakouts(breakouts: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    return deepcopy(list(breakouts)) if breakouts else []
+
+
+def _get_cached_breakouts(cache_key: Tuple[Any, ...]) -> Optional[List[Dict[str, Any]]]:
+    cached = _BREAKOUT_SIGNAL_CACHE.get(cache_key)
+    if cached is None:
+        return None
+    return deepcopy(cached)
+
+
+def _store_breakout_cache(
+    cache_key: Tuple[Any, ...], breakouts: Sequence[Mapping[str, Any]]
+) -> None:
+    _BREAKOUT_SIGNAL_CACHE[cache_key] = _clone_breakouts(breakouts)
+
+
+def _flatten_breakout_signal(signal: BaseSignal) -> Dict[str, Any]:
+    metadata = dict(signal.metadata or {})
+    metadata.setdefault("type", signal.type)
+    metadata.setdefault("symbol", signal.symbol)
+    metadata.setdefault("time", signal.time)
+    metadata.setdefault("confidence", signal.confidence)
+    return metadata
+
+
+_BREAKOUT_CACHE_SPECS.update(
+    {
+        PivotLevelIndicator.NAME: BreakoutCacheSpec(
+            breakout_rule_id="pivot_breakout",
+            retest_rule_id="pivot_retest",
+            cache_context_key=_PIVOT_BREAKOUT_CACHE_KEY,
+            ready_flag_key=_PIVOT_BREAKOUT_READY_FLAG,
+            initialised_flag_key=None,
+            config_signature_builder=_pivot_breakout_signature,
+            rule_signal_types={
+                "pivot_breakout": {"breakout"},
+                "pivot_retest": {"retest"},
+            },
+        ),
+        MarketProfileIndicator.NAME: BreakoutCacheSpec(
+            breakout_rule_id="market_profile_breakout",
+            retest_rule_id="market_profile_retest",
+            cache_context_key=_BREAKOUT_CACHE_KEY,
+            ready_flag_key=_BREAKOUT_READY_FLAG,
+            initialised_flag_key=_BREAKOUT_CACHE_INITIALISED,
+            config_signature_builder=_market_profile_breakout_signature,
+            rule_signal_types={
+                "market_profile_breakout": {"breakout"},
+                "market_profile_retest": {"retest"},
+            },
+            context_defaults={_BREAKOUT_CACHE_INITIALISED: True},
+        ),
+    }
+)
 
 
 def _normalize_color(value: Optional[str]) -> Optional[str]:
@@ -142,6 +337,7 @@ def delete_instance(inst_id: str) -> None:
     if inst_id not in _REGISTRY:
         raise KeyError("Indicator not found")
     del _REGISTRY[inst_id]
+    _purge_breakout_cache(inst_id)
 
 def create_instance(
     type_str: str,
@@ -226,6 +422,7 @@ def update_instance(
 
     captured = _extract_ctor_params(new_inst)
     entry["instance"] = new_inst
+    _purge_breakout_cache(inst_id)
     meta = _ensure_color(entry["meta"])
     meta["params"] = captured
     if name:
@@ -386,34 +583,157 @@ def generate_signals_for_instance(
         )
         rule_config["rule_payloads"] = payloads
 
-    enabled_rules = rule_config.get("enabled_rules")
-    if enabled_rules is not None and not enabled_rules:
-        # drop empty lists so downstream defaults apply
-        rule_config.pop("enabled_rules")
+    indicator_name = getattr(inst, "NAME", inst.__class__.__name__)
+    cache_spec = _BREAKOUT_CACHE_SPECS.get(indicator_name)
+
+    requested_rule_ids: Optional[Set[str]] = None
+    cache_key: Optional[Tuple[Any, ...]] = None
+    using_cached_breakouts = False
+    drop_breakout_from_response = False
+
+    enabled_rules_config = rule_config.get("enabled_rules")
+    if enabled_rules_config is not None:
+        normalised_rules: List[str] = []
+        seen: Set[str] = set()
+        for rule_id in enabled_rules_config:
+            if rule_id is None:
+                continue
+            rule_str = str(rule_id).strip()
+            if not rule_str:
+                continue
+            norm = rule_str.lower()
+            if norm not in seen:
+                normalised_rules.append(norm)
+                seen.add(norm)
+        if normalised_rules:
+            rule_config["enabled_rules"] = normalised_rules
+            requested_rule_ids = set(normalised_rules)
+        else:
+            rule_config.pop("enabled_rules")
+
+    if cache_spec is not None:
+        signature = cache_spec.config_signature_builder(rule_config)
+        cache_key = (
+            inst_id,
+            indicator_name,
+            sym,
+            interval,
+            start,
+            end,
+            signature,
+        )
+        if (
+            requested_rule_ids
+            and cache_spec.retest_rule_id in requested_rule_ids
+            and cache_spec.breakout_rule_id not in requested_rule_ids
+        ):
+            cached_breakouts = _get_cached_breakouts(cache_key)
+            if cached_breakouts:
+                using_cached_breakouts = True
+                rule_config[cache_spec.cache_context_key] = cached_breakouts
+                rule_config[cache_spec.ready_flag_key] = True
+                if cache_spec.initialised_flag_key:
+                    rule_config[cache_spec.initialised_flag_key] = True
+                for extra_key, extra_value in cache_spec.context_defaults.items():
+                    rule_config.setdefault(extra_key, extra_value)
+                logger.debug(
+                    "event=indicator_breakout_cache_hit indicator=%s rule=%s entries=%d",
+                    inst_id,
+                    cache_spec.breakout_rule_id,
+                    len(cached_breakouts),
+                )
+            else:
+                drop_breakout_from_response = True
+                current_rules = list(rule_config.get("enabled_rules", []))
+                if cache_spec.breakout_rule_id not in current_rules:
+                    current_rules.append(cache_spec.breakout_rule_id)
+                if current_rules:
+                    rule_config["enabled_rules"] = current_rules
+                logger.debug(
+                    "event=indicator_breakout_cache_miss indicator=%s rule=%s",
+                    inst_id,
+                    cache_spec.breakout_rule_id,
+                )
+
+    noisy_keys = {"rule_payloads"}
+    if cache_spec is not None:
+        noisy_keys.add(cache_spec.cache_context_key)
+
+    log_config: Dict[str, Any] = {}
+    for key, value in rule_config.items():
+        if key in noisy_keys:
+            try:
+                length = len(value)  # type: ignore[arg-type]
+            except Exception:
+                length = "?"
+            log_config[key] = f"<{key}:len={length}>"
+        else:
+            log_config[key] = value
 
     logger.info(
         "event=indicator_signal_execute indicator=%s name=%s symbol=%s interval=%s start=%s end=%s config=%s",
         inst_id,
-        getattr(inst, "NAME", inst.__class__.__name__),
+        indicator_name,
         sym,
         interval,
         start,
         end,
-        rule_config,
+        log_config,
     )
 
-    signals = run_indicator_rules(inst, df, **rule_config)
-    overlays = build_signal_overlays(inst, signals, df, **rule_config)
+    signals_all = run_indicator_rules(inst, df, **rule_config)
+
+    if cache_spec is not None and cache_key is not None and not using_cached_breakouts:
+        enabled_for_run = rule_config.get("enabled_rules")
+        ran_breakout = enabled_for_run is None or cache_spec.breakout_rule_id in enabled_for_run
+        if ran_breakout:
+            breakout_payloads = [
+                _flatten_breakout_signal(sig)
+                for sig in signals_all
+                if sig.type == "breakout"
+            ]
+            _store_breakout_cache(cache_key, breakout_payloads)
+            logger.debug(
+                "event=indicator_breakout_cache_store indicator=%s rule=%s entries=%d",
+                inst_id,
+                cache_spec.breakout_rule_id,
+                len(breakout_payloads),
+            )
+
+    filtered_signals: List[BaseSignal] = list(signals_all)
+    if cache_spec is not None:
+        if requested_rule_ids:
+            allowed_types: Set[str] = set()
+            for rule_id in requested_rule_ids:
+                allowed_types.update(cache_spec.rule_signal_types.get(rule_id, set()))
+            if allowed_types:
+                filtered_signals = [
+                    sig for sig in filtered_signals if sig.type in allowed_types
+                ]
+        if drop_breakout_from_response:
+            filtered_signals = [
+                sig for sig in filtered_signals if sig.type != "breakout"
+            ]
+
+    if len(filtered_signals) != len(signals_all):
+        logger.debug(
+            "event=indicator_signal_filtered indicator=%s total=%d returned=%d",
+            inst_id,
+            len(signals_all),
+            len(filtered_signals),
+        )
+
+    overlays = build_signal_overlays(inst, filtered_signals, df, **rule_config)
 
     logger.info(
         "event=indicator_signal_complete indicator=%s signals=%d overlays=%d",
         inst_id,
-        len(signals),
+        len(filtered_signals),
         len(overlays),
     )
 
     sanitized_overlays = _sanitize_json(overlays) or []
     return {
-        "signals": [sig.to_dict() for sig in signals],
+        "signals": [sig.to_dict() for sig in filtered_signals],
         "overlays": sanitized_overlays,
     }

--- a/portal/backend/service/indicator_service.py
+++ b/portal/backend/service/indicator_service.py
@@ -205,6 +205,42 @@ def _flatten_breakout_signal(signal: BaseSignal) -> Dict[str, Any]:
     return metadata
 
 
+def _build_market_profile_overlay_indicator(
+    indicator: MarketProfileIndicator,
+    df: pd.DataFrame,
+    *,
+    interval: Optional[str] = None,
+    symbol: Optional[str] = None,
+) -> MarketProfileIndicator:
+    """Create a fresh MarketProfileIndicator aligned with the overlay request window."""
+
+    runtime = MarketProfileIndicator(
+        df=df.copy(),
+        bin_size=getattr(indicator, "bin_size", 0.1),
+        mode=getattr(indicator, "mode", "tpo"),
+        interval=interval or getattr(indicator, "interval", "30m"),
+        extend_value_area_to_chart_end=getattr(
+            indicator,
+            "extend_value_area_to_chart_end",
+            True,
+        ),
+        use_merged_value_areas=getattr(indicator, "use_merged_value_areas", True),
+        merge_threshold=getattr(indicator, "merge_threshold", 0.6),
+        min_merge_sessions=getattr(
+            indicator,
+            "min_merge_sessions",
+            getattr(MarketProfileIndicator, "DEFAULT_MIN_MERGE_SESSIONS", 3),
+        ),
+    )
+
+    if symbol is None:
+        symbol = getattr(indicator, "symbol", None)
+    if symbol is not None:
+        setattr(runtime, "symbol", symbol)
+
+    return runtime
+
+
 _BREAKOUT_CACHE_SPECS.update(
     {
         PivotLevelIndicator.NAME: BreakoutCacheSpec(
@@ -469,11 +505,40 @@ def overlays_for_instance(
     if df is None or df.empty:
         raise LookupError("No candles available for given window")
 
+    overlay_indicator = inst
+    if isinstance(inst, MarketProfileIndicator) and hasattr(inst, "to_lightweight"):
+        overlay_indicator = _build_market_profile_overlay_indicator(
+            inst,
+            df,
+            interval=interval,
+            symbol=sym,
+        )
+        logger.debug(
+            "event=indicator_overlay_runtime_clone indicator=%s symbol=%s interval=%s",
+            inst_id,
+            sym,
+            interval,
+        )
+
     # Expect indicator to expose one of: to_lightweight(df) | to_overlays(df)
-    if hasattr(inst, "to_lightweight"):
-        payload = inst.to_lightweight(df)
-    elif hasattr(inst, "to_overlays"):
-        payload = inst.to_overlays(df)
+    if hasattr(overlay_indicator, "to_lightweight"):
+        payload = overlay_indicator.to_lightweight(
+            df,
+            use_merged=getattr(inst, "use_merged_value_areas", True),
+            merge_threshold=getattr(inst, "merge_threshold", 0.6),
+            min_merge=getattr(
+                inst,
+                "min_merge_sessions",
+                getattr(MarketProfileIndicator, "DEFAULT_MIN_MERGE_SESSIONS", 3),
+            ),
+            extend_boxes_to_chart_end=getattr(
+                inst,
+                "extend_value_area_to_chart_end",
+                True,
+            ),
+        )
+    elif hasattr(overlay_indicator, "to_overlays"):
+        payload = overlay_indicator.to_overlays(df)
     else:
         raise RuntimeError("Indicator does not implement overlay serialization")
 

--- a/portal/frontend/src/chart/paneViews/signalBubblePaneView.js
+++ b/portal/frontend/src/chart/paneViews/signalBubblePaneView.js
@@ -110,6 +110,12 @@ export function createSignalBubblePaneView(timeScaleApi) {
         const py = priceToCoordinate(Number(bubble.price));
         if (py == null) continue;
 
+        const canvasX = px * hpr;
+        const offscreenBuffer = 24 * hpr;
+        if (canvasX < -offscreenBuffer || canvasX > widthPx + offscreenBuffer) {
+          continue;
+        }
+
         const accent = bubble.accentColor ?? '#38bdf8';
         const background = bubble.backgroundColor ?? hexToRgba(accent, 0.12) ?? 'rgba(30,41,59,0.78)';
         const textColor = bubble.textColor ?? '#f8fafc';
@@ -141,7 +147,7 @@ export function createSignalBubblePaneView(timeScaleApi) {
 
         const pointerDir = direction === 'above' ? 'down' : 'up';
 
-        let bubbleX = px * hpr - bubbleWidth / 2;
+        let bubbleX = canvasX - bubbleWidth / 2;
         const minX = 12 * hpr;
         const maxX = widthPx - bubbleWidth - 12 * hpr;
         bubbleX = clamp(bubbleX, minX, Math.max(minX, maxX));

--- a/portal/frontend/src/components/ChartComponent/ChartComponent.jsx
+++ b/portal/frontend/src/components/ChartComponent/ChartComponent.jsx
@@ -64,6 +64,68 @@ const toRgba = (hex, alpha = 0.12) => {
   return `rgba(${r},${g},${b},${clampedAlpha})`;
 };
 
+const coalesce = (...values) => {
+  for (const value of values) {
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+};
+
+const toFiniteNumber = (value) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const toIsoFromSeconds = (value) => {
+  const numeric = toFiniteNumber(value);
+  if (numeric == null) return null;
+  try {
+    const date = new Date(numeric * 1000);
+    if (Number.isNaN(date.valueOf())) return null;
+    return date.toISOString();
+  } catch {
+    return null;
+  }
+};
+
+const formatPriceDisplay = (value) => {
+  const numeric = toFiniteNumber(value);
+  return numeric == null ? 'n/a' : numeric.toFixed(2);
+};
+
+const buildVaBoxSummaryText = ({
+  startSec,
+  endSec,
+  requestedEndSec,
+  val,
+  vah,
+  poc,
+  sessions,
+  valueAreaId,
+}) => {
+  const parts = [
+    `start=${toIsoFromSeconds(startSec) ?? 'n/a'}`,
+    `end=${toIsoFromSeconds(endSec) ?? 'n/a'}`,
+    `VAL=${formatPriceDisplay(val)}`,
+    `VAH=${formatPriceDisplay(vah)}`,
+  ];
+
+  if (poc != null) {
+    parts.push(`POC=${formatPriceDisplay(poc)}`);
+  }
+  if (sessions != null) {
+    parts.push(`sessions=${sessions}`);
+  }
+  if (valueAreaId != null) {
+    parts.push(`id=${valueAreaId}`);
+  }
+  if (requestedEndSec != null && requestedEndSec !== endSec) {
+    parts.push('extended_to_last_bar=true');
+  }
+
+  return parts.join(' | ');
+};
+
 export const ChartComponent = ({ chartId }) => {
   // Logger for this file.
   const logger = useMemo(() => createLogger(LOG_NS, { chartId }), [chartId]);
@@ -484,14 +546,16 @@ export const ChartComponent = ({ chartId }) => {
       // 3d) VA Boxes.
       if (paneViews.includes('va_box') && norm.boxes?.length) {
         const lastCandleSec = toSec(lastBarRef.current?.time);
-        const normalizedBoxes = norm.boxes.map((b, idxInGroup) => {
-          const x1 = toSec(b.x1);
-          const requestedX2 = toSec(b.x2);
+        const baseIndex = boxes.length;
+        const summaryEntries = [];
+        const normalizedBoxes = norm.boxes.map((box, idxInGroup) => {
+          const x1 = toSec(box.x1);
+          const requestedX2 = toSec(box.x2);
           const x2 = Number.isFinite(lastCandleSec) ? lastCandleSec : requestedX2;
 
           if (Number.isFinite(lastCandleSec) && lastCandleSec !== requestedX2) {
             overlayLogger.debug('va_box_span_adjusted', {
-              boxIndex: boxes.length + idxInGroup,
+              boxIndex: baseIndex + idxInGroup,
               x1,
               originalX2: requestedX2,
               forcedX2: x2,
@@ -499,13 +563,63 @@ export const ChartComponent = ({ chartId }) => {
             });
           }
 
+          const pocValue = toFiniteNumber(
+            coalesce(
+              box.poc,
+              box.POC,
+              box?.meta?.poc,
+              box?.metadata?.poc,
+            ),
+          );
+          const sessions = coalesce(
+            box.session_count,
+            box.sessions,
+            box.sessionCount,
+            box?.meta?.session_count,
+            box?.metadata?.session_count,
+          );
+          const valueAreaId = coalesce(
+            box.value_area_id,
+            box.valueAreaId,
+            box.value_areaId,
+            box.id,
+            box?.meta?.value_area_id,
+            box?.metadata?.value_area_id,
+          );
+          const label = coalesce(
+            box.label,
+            box.session_label,
+            box.session,
+            box.profile_label,
+          );
+          const sourceStart = coalesce(box.start, box.start_date, box.startDate);
+          const sourceEnd = coalesce(box.end, box.end_date, box.endDate);
+
+          const y1 = Number(box.y1);
+          const y2 = Number(box.y2);
+
+          summaryEntries.push({
+            index: baseIndex + idxInGroup + 1,
+            startSec: x1,
+            endSec: x2,
+            requestedEndSec: requestedX2,
+            val: Number.isFinite(y1) ? y1 : null,
+            vah: Number.isFinite(y2) ? y2 : null,
+            poc: pocValue,
+            sessions,
+            valueAreaId,
+            label,
+            sourceStart,
+            sourceEnd,
+          });
+
           return {
             x1,
             x2,
-            y1: Number(b.y1),
-            y2: Number(b.y2),
-            color: b.color,
-            border: b.border,
+            y1,
+            y2,
+            color: box.color,
+            border: box.border,
           };
         });
         boxes.push(...normalizedBoxes);
@@ -514,7 +628,7 @@ export const ChartComponent = ({ chartId }) => {
             ? Number(b.x2) - Number(b.x1)
             : null;
           overlayLogger.debug('va_box_applied', {
-            boxIndex: idx,
+            boxIndex: baseIndex + idx,
             x1: b.x1,
             x2: b.x2,
             y1: b.y1,
@@ -522,6 +636,23 @@ export const ChartComponent = ({ chartId }) => {
             width,
           });
         });
+
+        if (summaryEntries.length) {
+          overlayLogger.info('va_box_summary', {
+            appended: summaryEntries.length,
+            total: boxes.length,
+          });
+          summaryEntries.forEach((entry) => {
+            overlayLogger.info('va_box_summary_entry', {
+              index: entry.index,
+              detail: buildVaBoxSummaryText(entry),
+              valueAreaId: entry.valueAreaId ?? null,
+              label: entry.label ?? null,
+              sourceStart: entry.sourceStart ?? null,
+              sourceEnd: entry.sourceEnd ?? null,
+            });
+          });
+        }
       }
 
       if (paneViews.includes('segment') && norm.segments?.length) {

--- a/src/signals/rules/pivot.py
+++ b/src/signals/rules/pivot.py
@@ -39,6 +39,8 @@ class PivotBreakoutConfig:
 
 log = logging.getLogger("PivotBreakoutRule")
 
+_DEFAULT_RETEST_CONFIRMATION_BARS = 3
+
 _DEFAULT_CONFIG = PivotBreakoutConfig()
 _PIVOT_BREAKOUT_READY_FLAG = "_pivot_breakouts_ready"
 
@@ -478,7 +480,18 @@ def _detect_retest(
     if start_idx is None:
         return None
 
-    look_start = start_idx + max(min_bars, 1)
+    raw_confirmation = breakout_meta.get("confirmation_bars_required")
+    try:
+        confirmation_bars_required = int(raw_confirmation)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        confirmation_bars_required = _DEFAULT_RETEST_CONFIRMATION_BARS
+
+    if confirmation_bars_required < 0:
+        confirmation_bars_required = _DEFAULT_RETEST_CONFIRMATION_BARS
+
+    effective_min_bars = max(min_bars, confirmation_bars_required, 1)
+
+    look_start = start_idx + effective_min_bars
     if look_start >= len(df):
         return None
 
@@ -524,6 +537,7 @@ def _detect_retest(
             "level_kind": breakout_meta.get("level_kind"),
             "retest_role": "support" if breakout_direction == "above" else "resistance",
             "bars_since_breakout": bars_since,
+            "confirmation_bars_required": confirmation_bars_required,
             "retest_close": close,
             "retest_high": high,
             "retest_low": low,

--- a/tests/test_service/test_indicator_service_market_profile.py
+++ b/tests/test_service/test_indicator_service_market_profile.py
@@ -1,0 +1,50 @@
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from indicators.market_profile import MarketProfileIndicator
+from portal.backend.service.indicator_service import (
+    _build_market_profile_overlay_indicator,
+)
+
+
+def _make_df(end_timestamp: str) -> pd.DataFrame:
+    index = pd.date_range(
+        start="2025-08-01 13:30:00+00:00",
+        end=end_timestamp,
+        freq="15T",
+        tz="UTC",
+    )
+    data = {
+        "open": [70.0 + idx for idx in range(len(index))],
+        "high": [70.5 + idx for idx in range(len(index))],
+        "low": [69.5 + idx for idx in range(len(index))],
+        "close": [70.2 + idx for idx in range(len(index))],
+    }
+    return pd.DataFrame(data, index=index)
+
+
+def test_market_profile_overlay_indicator_uses_requested_dataframe():
+    original_df = _make_df("2025-08-01 19:30:00+00:00")
+    updated_df = _make_df("2025-08-01 19:45:00+00:00")
+
+    base_indicator = MarketProfileIndicator(original_df, interval="15m")
+
+    overlay_indicator = _build_market_profile_overlay_indicator(
+        base_indicator,
+        updated_df,
+        interval="15m",
+        symbol="CL",
+    )
+
+    assert overlay_indicator is not base_indicator
+
+    original_profile = base_indicator.daily_profiles[0]
+    overlay_profile = overlay_indicator.daily_profiles[0]
+
+    assert original_profile["end_date"].isoformat() == "2025-08-01T19:30:00+00:00"
+    assert overlay_profile["end_date"].isoformat() == "2025-08-01T19:45:00+00:00"
+
+    assert overlay_indicator.use_merged_value_areas == base_indicator.use_merged_value_areas
+    assert overlay_indicator.merge_threshold == base_indicator.merge_threshold
+    assert overlay_indicator.min_merge_sessions == base_indicator.min_merge_sessions

--- a/tests/test_signals/test_market_profile_rules.py
+++ b/tests/test_signals/test_market_profile_rules.py
@@ -428,3 +428,75 @@ def test_detect_value_area_retest_respects_value_area_end_index():
     )
 
     assert retest is None
+
+
+def test_detect_value_area_retest_waits_for_confirmation_requirement():
+    index = pd.date_range("2025-04-01 09:30", periods=7, freq="30min", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [109.2, 109.6, 111.2, 110.8, 110.7, 110.5, 110.3],
+            "high": [109.6, 110.0, 111.8, 111.2, 111.0, 110.8, 110.6],
+            "low": [108.9, 109.4, 110.9, 109.95, 110.4, 110.3, 110.2],
+            "close": [109.5, 110.2, 111.6, 110.6, 110.9, 110.7, 110.5],
+        },
+        index=index,
+    )
+
+    breakout_meta = {
+        "level_price": 110.0,
+        "breakout_direction": "above",
+        "trigger_bar_index": 2,
+        "trigger_time": index[2].to_pydatetime(),
+        "value_area_id": "session-confirm",
+        "value_area_start_index": 0,
+        "value_area_end_index": len(df) - 1,
+        "confirmation_bars_required": 3,
+    }
+
+    retest = _detect_value_area_retest(
+        df,
+        breakout_meta,
+        tolerance_pct=0.0015,
+        max_bars=5,
+        min_bars=1,
+        mode="backtest",
+    )
+
+    assert retest is None
+
+
+def test_detect_value_area_retest_emits_after_confirmation_requirement():
+    index = pd.date_range("2025-04-02 09:30", periods=7, freq="30min", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [209.2, 209.6, 211.2, 210.8, 210.7, 210.5, 210.3],
+            "high": [209.6, 210.0, 211.8, 211.2, 211.0, 210.8, 210.6],
+            "low": [208.9, 209.4, 210.9, 209.95, 210.4, 209.98, 210.2],
+            "close": [209.5, 210.2, 211.6, 210.6, 210.9, 210.55, 210.4],
+        },
+        index=index,
+    )
+
+    breakout_meta = {
+        "level_price": 210.0,
+        "breakout_direction": "above",
+        "trigger_bar_index": 2,
+        "trigger_time": index[2].to_pydatetime(),
+        "value_area_id": "session-confirm-2",
+        "value_area_start_index": 0,
+        "value_area_end_index": len(df) - 1,
+        "confirmation_bars_required": 3,
+    }
+
+    retest = _detect_value_area_retest(
+        df,
+        breakout_meta,
+        tolerance_pct=0.0015,
+        max_bars=5,
+        min_bars=1,
+        mode="backtest",
+    )
+
+    assert retest is not None
+    assert retest["bars_since_breakout"] == 3
+    assert retest["confirmation_bars_required"] == 3

--- a/tests/test_signals/test_pivot_breakout_rule.py
+++ b/tests/test_signals/test_pivot_breakout_rule.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pytest
 
 pd = pytest.importorskip("pandas")
@@ -5,7 +7,7 @@ pd = pytest.importorskip("pandas")
 from indicators.pivot_level import Level
 from signals.base import BaseSignal
 from signals.rules import PivotBreakoutConfig, pivot_breakout_rule
-from signals.rules.pivot import pivot_signals_to_overlays
+from signals.rules.pivot import _detect_retest, pivot_signals_to_overlays
 
 
 class DummyPivotIndicator:
@@ -60,6 +62,29 @@ def _build_dataframe_from_ohlc(rows):
         data["low"].append(float(low))
         data["close"].append(float(close))
         data["volume"].append(1000.0)
+
+    return pd.DataFrame(data, index=index)
+
+
+def _build_touch_dataframe(*, level_price: float, touch_after: Optional[int] = None, final_touch: Optional[int] = None) -> pd.DataFrame:
+    """Construct a dataframe with optional retest touches for confirmation tests."""
+
+    index = pd.date_range("2025-01-01", periods=7, freq="H")
+    base_prices = [level_price - 1.5, level_price - 0.7, level_price + 2.1, level_price + 1.8, level_price + 1.6, level_price + 1.5, level_price + 1.4]
+
+    lows = [price - 0.5 for price in base_prices]
+    if touch_after is not None and 0 <= touch_after < len(lows):
+        lows[touch_after] = level_price - 0.05
+    if final_touch is not None and 0 <= final_touch < len(lows):
+        lows[final_touch] = level_price - 0.02
+
+    data = {
+        "open": [price - 0.2 for price in base_prices],
+        "high": [price + 0.4 for price in base_prices],
+        "low": lows,
+        "close": base_prices,
+        "volume": [1000.0] * len(index),
+    }
 
     return pd.DataFrame(data, index=index)
 
@@ -362,3 +387,53 @@ def test_pivot_breakout_overlay_bubble_uses_support_color_after_flip():
     bubbles = overlays[0]["payload"]["bubbles"]
     support_bubble = next(b for b in bubbles if b["label"] == "Support breakdown")
     assert support_bubble["accentColor"] == "#22c55e"
+
+
+def test_detect_retest_requires_confirmation_bars():
+    level_price = 100.0
+    df = _build_touch_dataframe(level_price=level_price, touch_after=3)
+
+    breakout_meta = {
+        "level_price": level_price,
+        "breakout_direction": "above",
+        "trigger_time": df.index[2].to_pydatetime(),
+        "trigger_bar_index": 2,
+        "confirmation_bars_required": 3,
+    }
+
+    result = _detect_retest(
+        df,
+        breakout_meta,
+        tolerance_pct=0.0015,
+        max_bars=5,
+        min_bars=1,
+        mode="backtest",
+    )
+
+    assert result is None
+
+
+def test_detect_retest_emits_after_confirmation_wait():
+    level_price = 100.0
+    df = _build_touch_dataframe(level_price=level_price, touch_after=3, final_touch=5)
+
+    breakout_meta = {
+        "level_price": level_price,
+        "breakout_direction": "above",
+        "trigger_time": df.index[2].to_pydatetime(),
+        "trigger_bar_index": 2,
+        "confirmation_bars_required": 3,
+    }
+
+    result = _detect_retest(
+        df,
+        breakout_meta,
+        tolerance_pct=0.0015,
+        max_bars=5,
+        min_bars=1,
+        mode="backtest",
+    )
+
+    assert result is not None
+    assert result["bars_since_breakout"] == 3
+    assert result["confirmation_bars_required"] == 3


### PR DESCRIPTION
## Summary
- add reusable breakout caching metadata and helpers for signal generation requests
- reuse cached breakout payloads when serving retest-only requests for pivot and market profile indicators
- clear cached breakouts when indicators are updated or deleted and suppress breakout overlays when only retests are requested

## Testing
- python -m compileall portal/backend/service/indicator_service.py

------
https://chatgpt.com/codex/tasks/task_e_68de0450c4b08331afb6572618d3a40c