### PR TITLE
Update market profile breakout confirmation defaults

### DIFF
--- a/portal/backend/service/indicator_service.py
+++ b/portal/backend/service/indicator_service.py
@@ -626,7 +626,7 @@ def generate_signals_for_instance(
 
     rule_config: Dict[str, Any] = dict(config or {})
     rule_config.setdefault("pivot_breakout_confirmation_bars", 3)
-    rule_config.setdefault("market_profile_breakout_confirmation_bars", 1)
+    rule_config.setdefault("market_profile_breakout_confirmation_bars", 3)
     rule_config.setdefault("symbol", sym)
 
     if isinstance(inst, MarketProfileIndicator) and "rule_payloads" not in rule_config:

--- a/src/signals/rules/market_profile.py
+++ b/src/signals/rules/market_profile.py
@@ -30,7 +30,7 @@ _BREAKOUT_READY_FLAG = "_market_profile_breakouts_ready"
 class MarketProfileBreakoutConfig:
     """Configuration for Market Profile breakout confirmations."""
 
-    confirmation_bars: int = 1
+    confirmation_bars: int = 3
     early_confirmation_window: int = 3
     early_confirmation_distance_pct: float = 0.01
 

--- a/tests/test_signals/test_market_profile_rules.py
+++ b/tests/test_signals/test_market_profile_rules.py
@@ -49,11 +49,12 @@ def sample_context(sample_market_profile_df):
         "symbol": "TEST",
         "mode": "backtest",
         "market_profile_breakout_min_age_hours": 0,
-        "market_profile_breakout_confirmation_bars": 1,
     }
 
 
 def test_breakout_evaluator_detects_multiple_events(sample_context, sample_value_area, sample_market_profile_df):
+    sample_context["market_profile_breakout_confirmation_bars"] = 1
+
     metas = _value_area_breakout_evaluator(sample_context, sample_value_area)
     assert len(metas) == 2
 
@@ -307,6 +308,8 @@ def test_breakout_evaluator_live_mode_honours_confirmation(sample_value_area):
 
 
 def test_retest_rule_emits_retests_for_cached_breakouts(sample_context, sample_value_area):
+    sample_context["market_profile_breakout_confirmation_bars"] = 1
+
     breakouts = market_profile_breakout_rule(sample_context, sample_value_area)
     assert len(breakouts) == 2
     assert len(sample_context[_BREAKOUT_CACHE_KEY]) == 2


### PR DESCRIPTION
## Summary
- align the indicator service default market profile breakout confirmation with the three-bar standard
- update the market profile breakout configuration default confirmation bars to three
- adjust the market profile rule tests to override the confirmation setting explicitly when they expect a single bar

## Testing
- pytest tests/test_signals/test_market_profile_rules.py

------
https://chatgpt.com/codex/tasks/task_e_68de1a7dd1a08331b92d9f5e4d2c89f1