### PR TITLE
Mount secrets env and fix tsdb hostname resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Strategies can register the same indicator multiple times with different configu
 git clone --branch develop https://github.com/elijahbrookss/quant-trad.git
 cd quant-trad
 
+# Copy credentials template and add your Alpaca keys (file stays local)
+cp secrets.env.example secrets.env
+# Then edit secrets.env with ALPACA_API_KEY and ALPACA_SECRET_KEY
+
 # Create dev setup
 make dev
 
@@ -92,3 +96,10 @@ make db_cli
 
 # Shut down services when done
 make shutdown
+```
+
+### Secrets configuration
+
+- `secrets.env` is ignored by Git but required locally for features that call the Alpaca API.
+- Start by copying `secrets.env.example` to `secrets.env` and populate `ALPACA_API_KEY` and `ALPACA_SECRET_KEY`.
+- When you run `docker compose` the file is bind-mounted into the backend container, so your keys stay on the host machine while remaining available to the app.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     labels:
       loki.job: quanttrad
       loki.service: backend
+    env_file:
+      - ../secrets.env
     environment:
       PYTHONPATH: /app/src:/app
       PG_DSN: postgresql+psycopg2://quanttrad:quanttrad@tsdb.quanttrad:5432/quanttrad
@@ -36,6 +38,8 @@ services:
       - "8000:8000"
     depends_on:
       - tsdb
+    volumes:
+      - ../secrets.env:/app/secrets.env:ro
     networks:
       quanttrad:
         aliases:
@@ -44,6 +48,7 @@ services:
   tsdb:
     profiles: [database]
     image: timescale/timescaledb:2.14.2-pg15
+    hostname: tsdb.quanttrad
     labels:
       loki.job: quanttrad
       loki.service: tsdb
@@ -56,7 +61,9 @@ services:
     volumes:
       - tsdb-data:/var/lib/postgresql/data
     networks:
-      - quanttrad
+      quanttrad:
+        aliases:
+          - tsdb.quanttrad
 
   pgadmin:
     profiles: [database]

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -1,0 +1,7 @@
+# Copy this file to `secrets.env` and fill in your private credentials.
+# This file is used by the trading engine and Docker services to authenticate
+# against Alpaca. The actual `secrets.env` file is git-ignored so your keys
+# remain local.
+
+ALPACA_API_KEY=replace-with-your-key
+ALPACA_SECRET_KEY=replace-with-your-secret


### PR DESCRIPTION
## Summary
- mount the developer `secrets.env` file into the backend Docker service so Alpaca credentials are available in-container
- add a `secrets.env.example` template and update the README with instructions for managing Alpaca keys locally
- ensure the TimescaleDB service is addressable as `tsdb.quanttrad` so the backend PG_DSN resolves correctly

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de39aafa788331a25cae1e8574f74a