### PR TITLE
Fix Loki configuration for recent versions

### DIFF
--- a/docker/loki/config.yml
+++ b/docker/loki/config.yml
@@ -30,7 +30,6 @@ storage_config:
   boltdb_shipper:
     active_index_directory: /loki/index
     cache_location: /loki/cache
-    shared_store: filesystem
   filesystem:
     directory: /loki/chunks
 
@@ -38,9 +37,7 @@ limits_config:
   max_query_series: 100000
   reject_old_samples: true
   reject_old_samples_max_age: 168h
-
-chunk_store_config:
-  max_look_back_period: 168h
+  max_query_lookback: 168h
 
 ruler:
   storage:


### PR DESCRIPTION
## Summary
- remove deprecated `shared_store` and chunk store options from the Loki config
- configure `max_query_lookback` to preserve the previous retention window

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de4737454c8331b123698505ce3e71