### PR TITLE
Remove overlay helper kwargs injection for pivot levels

### DIFF
--- a/portal/backend/service/indicator_service.py
+++ b/portal/backend/service/indicator_service.py
@@ -522,33 +522,7 @@ def overlays_for_instance(
 
     # Expect indicator to expose one of: to_lightweight(df) | to_overlays(df)
     if hasattr(overlay_indicator, "to_lightweight"):
-        to_lightweight = overlay_indicator.to_lightweight
-        signature = inspect.signature(to_lightweight)
-        extra_kwargs: dict[str, Any] = {}
-
-        if len(signature.parameters) > 1:
-            param_names = set(signature.parameters.keys()) - {"df"}
-
-            def maybe_add(param: str, value: Any) -> None:
-                if param in param_names:
-                    extra_kwargs[param] = value
-
-            maybe_add("use_merged", getattr(inst, "use_merged_value_areas", True))
-            maybe_add("merge_threshold", getattr(inst, "merge_threshold", 0.6))
-            maybe_add(
-                "min_merge",
-                getattr(
-                    inst,
-                    "min_merge_sessions",
-                    getattr(MarketProfileIndicator, "DEFAULT_MIN_MERGE_SESSIONS", 3),
-                ),
-            )
-            maybe_add(
-                "extend_boxes_to_chart_end",
-                getattr(inst, "extend_value_area_to_chart_end", True),
-            )
-
-        payload = to_lightweight(df, **extra_kwargs)
+        payload = overlay_indicator.to_lightweight(df)
     elif hasattr(overlay_indicator, "to_overlays"):
         payload = overlay_indicator.to_overlays(df)
     else:

--- a/src/indicators/pivot_level.py
+++ b/src/indicators/pivot_level.py
@@ -306,7 +306,7 @@ class PivotLevelIndicator(BaseIndicator):
     def to_lightweight(
         self,
         plot_df: pd.DataFrame,
-        color_mode: str = 'timeframe'
+        color_mode: str = 'timeframe',
     ) -> Dict[str, Any]:
         """
         Produce TradingView Lightweight Charts overlays:


### PR DESCRIPTION
## Summary
- stop `overlays_for_instance` from injecting market-profile-specific keyword arguments when calling `to_lightweight`
- revert the pivot-level lightweight serializer to its original signature now that unexpected kwargs are no longer forwarded

## Testing
- pytest tests/test_indicators/test_pivot_level_indicator.py::test_find_pivots -q *(fails: missing pandas dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deb0e9ec548331b2e21315bce4d769