### PR TITLE
Add provider cache alias and reset helper; expose IB fetch as instance method

### DIFF
--- a/src/data_providers/providers/factory.py
+++ b/src/data_providers/providers/factory.py
@@ -149,12 +149,15 @@ class ProviderRegistry:
 
 
 _REGISTRY = ProviderRegistry()
+_PROVIDER_CACHE = _REGISTRY.cache
 
 
 def configure_persistence_factory(factory):
     """Provide a service-layer persistence builder for provider instances."""
 
+    global _PROVIDER_CACHE
     _REGISTRY.configure_persistence_factory(factory)
+    _PROVIDER_CACHE = _REGISTRY.cache
 
 
 def _resolve_ids(provider_id: Optional[str], venue_id: Optional[str]) -> Tuple[str, Optional[str]]:
@@ -176,6 +179,14 @@ def _resolve_ids(provider_id: Optional[str], venue_id: Optional[str]) -> Tuple[s
             venue = provider_cfg.supported_venues[0]
 
     return provider, venue
+
+
+def reset_provider_cache(cache: Optional[dict[Tuple[str, str], BaseDataProvider]] = None) -> None:
+    """Reset provider instance cache for tests and process-lifecycle hooks."""
+
+    global _PROVIDER_CACHE
+    _REGISTRY.cache = {} if cache is None else cache
+    _PROVIDER_CACHE = _REGISTRY.cache
 
 
 def get_provider(provider_id: Optional[str] = None, *, venue: Optional[str] = None, exchange: Optional[str] = None) -> BaseDataProvider:

--- a/src/data_providers/providers/interactive_brokers.py
+++ b/src/data_providers/providers/interactive_brokers.py
@@ -184,6 +184,17 @@ class InteractiveBrokersProvider(BaseDataProvider):
 
         self._resolve_contract_details(symbol)
 
+    def fetch_from_api(
+        self,
+        symbol: str,
+        start: dt.datetime | str,
+        end: dt.datetime | str,
+        interval: str,
+    ) -> pd.DataFrame:
+        """Retrieve OHLCV bars for *symbol* between *start* and *end*."""
+
+        return _fetch_from_api_impl(self, symbol, start, end, interval)
+
     def _resolve_contract_details(self, symbol: str) -> Tuple[Contract, list]:
         if not symbol:
             raise ValueError("symbol is required for Interactive Brokers validation")
@@ -216,7 +227,7 @@ class InteractiveBrokersProvider(BaseDataProvider):
 # ------------------------------------------------------------------
 # Public helpers
 # ------------------------------------------------------------------
-def fetch_from_api(
+def _fetch_from_api_impl(
     self,
     symbol: str,
     start: dt.datetime | str,
@@ -566,7 +577,6 @@ def _build_contract(self, symbol: str) -> Contract:
 
 
 for _method_name in (
-    "fetch_from_api",
     "_ensure_connection",
     "_ensure_event_loop",
     "_parse_exchange",
@@ -581,6 +591,7 @@ for _method_name in (
     "_build_contract",
 ):
     setattr(InteractiveBrokersProvider, _method_name, globals()[_method_name])
+
 
 
 @_REGISTRY.provider(

--- a/tests/test_data_providers/test_interactive_brokers.py
+++ b/tests/test_data_providers/test_interactive_brokers.py
@@ -81,7 +81,7 @@ def test_factory_returns_ib_provider(monkeypatch):
     """The provider factory should instantiate and cache the IB implementation."""
 
     _patch_ib_dependencies(monkeypatch)
-    monkeypatch.setattr(provider_factory, "_PROVIDER_CACHE", {})
+    provider_factory.reset_provider_cache()
 
     provider = provider_factory.get_provider(DataSource.IBKR.value, exchange="SMART")
     assert isinstance(provider, ib_module.InteractiveBrokersProvider)
@@ -105,3 +105,10 @@ def test_ib_provider_fetches_history(monkeypatch):
     assert list(frame.columns) == ["timestamp", "open", "high", "low", "close", "volume"]
     assert not frame.empty
     assert frame["timestamp"].dt.tz is not None
+
+
+def test_factory_legacy_cache_alias_points_to_registry_cache():
+    """Legacy cache alias should remain a live view of the registry cache."""
+
+    provider_factory.reset_provider_cache()
+    assert provider_factory._PROVIDER_CACHE is provider_factory._REGISTRY.cache


### PR DESCRIPTION
### Motivation

- Provide a stable legacy alias for the provider instance cache and a programmatic way to reset it for tests and lifecycle hooks.
- Surface the Interactive Brokers `fetch_from_api` as an instance method while keeping the existing implementation as a module-level helper.

### Description

- Introduce `_PROVIDER_CACHE` as an alias to `_REGISTRY.cache` and update it after persistence configuration in `configure_persistence_factory` by assigning `_PROVIDER_CACHE = _REGISTRY.cache`.
- Add `reset_provider_cache(cache: Optional[dict[...] ] = None) -> None` to reinitialize `_REGISTRY.cache` (and `_PROVIDER_CACHE`) for tests and process-lifecycle usage.
- Expose `InteractiveBrokersProvider.fetch_from_api` as an instance method that delegates to the existing implementation ` _fetch_from_api_impl`, and rename the module-level function from `fetch_from_api` to `_fetch_from_api_impl` to reflect its helper status.
- Update tests to use `provider_factory.reset_provider_cache()` instead of mutating `_PROVIDER_CACHE` and add `test_factory_legacy_cache_alias_points_to_registry_cache` to assert the legacy alias is a live view of the registry cache.

### Testing

- Ran unit tests in `tests/test_data_providers/test_interactive_brokers.py`, which include the updated caching test and IB fetch tests, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abd76c1b8083319f5a6f8d0773f1f3)